### PR TITLE
feat(blackbox): dkg-kc-publisher — batched knowledge-collection publishing toolkit

### DIFF
--- a/scripts/dkg-kc-publisher/.gitignore
+++ b/scripts/dkg-kc-publisher/.gitignore
@@ -1,0 +1,4 @@
+batches/
+registry.json
+*.log
+node_modules/

--- a/scripts/dkg-kc-publisher/README.md
+++ b/scripts/dkg-kc-publisher/README.md
@@ -1,0 +1,134 @@
+# DKG Knowledge-Collection Publisher
+
+Publish large datasets to the OriginTrail DKG (V10, Base mainnet) as **batched
+knowledge collections** — one on-chain transaction per ~1,000 records instead
+of one per record. Every record still becomes an individually-addressable,
+SPARQL-queryable knowledge asset inside its collection.
+
+**Why batch:** on-chain gas is per *transaction*; TRAC is per *byte × epoch*.
+Batching collapses the gas side ~1,000× while leaving the TRAC side unchanged.
+Measured on Base mainnet (July 2026), per 1,000-record collection (~2 MB
+payload, ~12k triples):
+
+| Cost | Amount |
+|---|---|
+| Gas (mint tx) | ~0.25–1M gas ≈ **$0.00001–0.0001** |
+| TRAC (1 epoch = 30 days) | **~1.1 TRAC** (0.0008 TRAC/KB/epoch network price) |
+| One-time CG registration | **~100 TRAC** deposit (RFC-53), charged at first mint |
+
+A 460k-record dataset ≈ 460 transactions ≈ **<$1 of ETH + ~510 TRAC per epoch**.
+Per-record minting of the same dataset would be ~$5,000–14,000 of gas.
+
+## Prerequisites
+
+- A **DKG V10 edge node** on Base mainnet (`dkg start`, API on :9200), with
+  its auth token readable (default `~/.dkg-mainnet/auth.token`).
+- Node ≥ 20 (scripts use built-in `fetch`; no npm dependencies).
+- **Funding — two wallets, and this will bite you if you skip it:**
+  - The node's *operational wallet 0* pays the one-time ~100 TRAC CG
+    registration deposit.
+  - The mint itself is signed by the CG's **on-chain authorized publisher
+    wallet** — often a *different* operational wallet of the node (check
+    `wallets.json`, and the daemon log line `Signing on-chain publish
+    (… signer=0x…)`). That wallet needs a small ETH float (~0.001) and enough
+    TRAC for the publish costs. "insufficient funds … have 0" on mint = this.
+
+## Quick start
+
+```bash
+# 1. Adapt mapping.mjs to your data (recordKey / recordQuads / extractRecords).
+
+# 2. Slice the source into deduplicated batches (default 1000 records each):
+node chunk.mjs path/to/your-data.json --size 1000
+
+# 3. Validate everything without spending:
+KC_CG_ID=my-dataset node publish.mjs --dry-run
+
+# 4. Publish (creates the CG if needed, then one PAID tx per batch):
+KC_CG_ID=my-dataset KC_CG_NAME="My Dataset" KC_EPOCHS=12 node publish.mjs
+
+# Or one batch at a time:
+KC_CG_ID=my-dataset node publish.mjs --batch batch-001
+```
+
+`registry.json` is the resumable ledger — a batch with a `txHash` is never
+re-paid; kill/re-run is always safe. Verify content afterwards:
+
+```bash
+curl -s -X POST http://127.0.0.1:9200/api/query \
+  -H "authorization: Bearer $(head -1 ~/.dkg-mainnet/auth.token)" \
+  -H 'content-type: application/json' \
+  -d '{"contextGraphId":"my-dataset","sparql":"SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s ?p ?o }"}'
+```
+
+## Configuration
+
+| Env | Default | Meaning |
+|---|---|---|
+| `DKG_ENDPOINT` / `DKG_PORT` | `http://127.0.0.1` / `9200` | node API |
+| `DKG_AUTH_TOKEN_PATH` | `~/.dkg-mainnet/auth.token` | Bearer token file |
+| `KC_NETWORK` | `mainnet-base` | expected `networkConfig`; publisher refuses any other node |
+| `KC_CG_ID` / `KC_CG_NAME` | `my-collection` | context graph id / display name |
+| `KC_EPOCHS` | `1` | storage epochs (30 days each) — TRAC scales linearly; extend later via `extendKnowledgeAssetLifetime` |
+| `KC_ATTEMPTS` | `3` | max mint attempts per batch (see "store overload" below) |
+
+## Sizing
+
+~1,000 records ≈ 12k triples ≈ 2 MB request payload. The node caps request
+bodies around 10 MB, and the publisher refuses payloads >9 MB — if your
+records are fat, lower `--size`. TRAC cost = `0.0008 × payloadKB × epochs`
+(read the live price from AskStorage via the Hub if you want it exact).
+
+## Operational gotchas (each of these cost us real debugging time)
+
+1. **Public Base RPCs throttle the node.** The node's chain reads race a
+   hard-coded 2.5 s timeout; `mainnet.base.org` can take 60 s under burst,
+   drpc 429s. Symptom: mint refused with `LU-5/LU-11: publish access-policy
+   is unknown`. Fix: run the bundled caching proxy and point the node at it —
+   ```bash
+   node rpc-proxy.mjs &          # listens on 127.0.0.1:8547
+   # ~/.dkg-mainnet/config.json → "chain": {"rpcUrl": "http://127.0.0.1:8547", "rpcUrls": ["http://127.0.0.1:8547"]}
+   dkg stop && dkg start
+   ```
+   The proxy caches read-only calls (15 s TTL), dedupes concurrent identical
+   reads, rotates upstreams on 429, and never caches nonces/tx submission.
+
+2. **Do not hammer mint retries when the node's store is busy.** The mint
+   internally runs a large CONSTRUCT ("lift") against the node's Oxigraph
+   store with a 30 s client timeout — but an aborted query keeps running
+   server-side. Rapid retries stack queries until Oxigraph pegs every core
+   for half an hour. If mints keep timing out: **restart the daemon (fresh
+   store queue) and mint immediately**, one attempt at a time
+   (`KC_ATTEMPTS=1`). On a node without other heavy content this rarely
+   triggers at all.
+
+3. **Duplicate records.** A rootEntity URI can exist only once per context
+   graph ("Rule 4" validation error). `chunk.mjs` dedupes globally by
+   `recordKey()` before batching — make sure your key really is stable and
+   unique per logical entity.
+
+4. **No typed dateTimes.** `^^xsd:dateTime` literals hit a canonicalization
+   skew between publisher and peers on mainnet and the mint fails. Publish
+   timestamps as plain string literals (the example mapping does).
+
+5. **No blank nodes; literals < ~100 KB.** The node rejects blank-node
+   objects and tombstones oversized literals. The publisher pre-validates
+   both before spending anything.
+
+6. **Stale share after a daemon restart.** If a mint 409s with *"not a
+   complete full share resident in Shared Memory"*, the publisher
+   automatically discards the draft, reseals, and retries — no action needed,
+   just noted so the log line doesn't surprise you.
+
+7. **CG registration is automatic but not free.** The first mint on a new CG
+   registers it on-chain and charges the ~100 TRAC RFC-53 deposit from the
+   node's operational wallet. Budget for it; it happens once per CG.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `mapping.mjs` | **your adaptation point** — record → key + quads |
+| `chunk.mjs` | source file → deduplicated `batches/batch-NNN.json` |
+| `publish.mjs` | CG ensure → seal/share → one paid mint per batch, resumable ledger |
+| `rpc-proxy.mjs` | local caching Base-RPC proxy (gotcha #1) |

--- a/scripts/dkg-kc-publisher/chunk.mjs
+++ b/scripts/dkg-kc-publisher/chunk.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Chunker — slice a source file into deterministic N-record batch files under
+ * batches/, deduplicated globally by recordKey() so no rootEntity ever repeats
+ * across collections (the publish validator rejects that).
+ *
+ * Usage:
+ *   node chunk.mjs <source.json> [--size 1000] [--max-batches 0]
+ *
+ * Re-running with the same source produces identical batches, so it composes
+ * with the publisher's resumable ledger.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { recordKey, extractRecords } from './mapping.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const argv = process.argv.slice(2);
+const src = argv.find((a) => !a.startsWith('--'));
+const flag = (name, dflt) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? Number(argv[i + 1]) : dflt;
+};
+const SIZE = flag('size', 1000);
+const MAX = flag('max-batches', 0); // 0 = all
+
+if (!src) { console.error('usage: node chunk.mjs <source.json> [--size 1000] [--max-batches 0]'); process.exit(1); }
+
+console.log('reading', src, '...');
+const records = extractRecords(JSON.parse(readFileSync(src, 'utf8')));
+console.log(`source: ${records.length} records`);
+
+const outDir = join(here, 'batches');
+mkdirSync(outDir, { recursive: true });
+
+const seen = new Set();
+let batch = [], n = 0, dupes = 0;
+const flush = () => {
+  if (!batch.length) return false;
+  n += 1;
+  const name = `batch-${String(n).padStart(3, '0')}`;
+  writeFileSync(join(outDir, `${name}.json`), JSON.stringify({ name, records: batch }));
+  console.log(`${name}: ${batch.length} records`);
+  batch = [];
+  return MAX > 0 && n >= MAX;
+};
+
+for (const r of records) {
+  const k = recordKey(r);
+  if (seen.has(k)) { dupes += 1; continue; }
+  seen.add(k);
+  batch.push(r);
+  if (batch.length === SIZE && flush()) break;
+}
+if (!(MAX > 0 && n >= MAX)) flush(); // trailing partial batch
+
+console.log(`done: ${n} batches, ${seen.size} unique records, ${dupes} duplicates skipped`);

--- a/scripts/dkg-kc-publisher/mapping.mjs
+++ b/scripts/dkg-kc-publisher/mapping.mjs
@@ -1,0 +1,103 @@
+/**
+ * Record → RDF mapping. THIS IS THE FILE YOU ADAPT for your own dataset.
+ *
+ * Two exports:
+ *   recordKey(record)   -> stable string key; drives the entity URI and dedup.
+ *                          Two records with the same key are THE SAME entity —
+ *                          the DKG rejects re-minting an existing rootEntity
+ *                          in a context graph (validation "Rule 4").
+ *   recordQuads(record) -> array of {subject, predicate, object, graph:''}
+ *                          quads for one record.
+ *
+ * RDF term rules (V10 node API):
+ *   - subject/predicate: bare absolute IRIs (no <>)
+ *   - object: bare absolute IRI, OR an N-Triples-quoted literal ("...")
+ *   - NO blank nodes (rejected by the node) — skolemize lists if you need them
+ *   - keep literals well under ~100 KB (oversize literals are tombstoned)
+ *   - publish timestamps as PLAIN string literals; typed ^^xsd:dateTime hits a
+ *     publisher↔peer canonicalization skew on Base mainnet (mint fails)
+ *
+ * The example below maps AI/security threat signals (dependency advisories,
+ * IOCs, prompt-injection patterns). Replace with your own schema.
+ */
+import { createHash } from 'node:crypto';
+
+const NS = 'urn:defender:';              // change to your project namespace
+const P = `${NS}p:`;
+const SCHEMA = 'http://schema.org/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const esc = (s) => String(s)
+  .replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  .replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+const lit = (s) => `"${esc(s)}"`;
+const sha = (s) => createHash('sha256').update(s, 'utf8').digest('hex').slice(0, 24);
+
+export function recordKey(s) {
+  switch (s.type) {
+    case 'dependency': return `dep:${s.ecosystem}:${s.package}@${s.version}`;
+    case 'ioc': return `ioc:${s.value}`;
+    case 'injection': return `injection:${s.pattern}`;
+    case 'skill': return `skill:${s.title ?? s.pattern ?? JSON.stringify(s)}`;
+    default: return `rec:${JSON.stringify(s)}`;
+  }
+}
+
+const TYPE_IRI = {
+  dependency: `${NS}DependencySignal`,
+  ioc: `${NS}IocSignal`,
+  injection: `${NS}InjectionSignal`,
+  skill: `${NS}SkillSignal`,
+};
+
+export function recordQuads(s) {
+  const subj = `${NS}signal:${sha(recordKey(s))}`;
+  const q = [];
+  const add = (p, o) => { if (o !== undefined && o !== null && o !== '') q.push({ subject: subj, predicate: p, object: o, graph: '' }); };
+  const addLit = (p, v) => { if (v !== undefined && v !== null && v !== '') add(p, lit(v)); };
+
+  add(RDF_TYPE, TYPE_IRI[s.type] ?? `${NS}Signal`);
+  addLit(SCHEMA + 'name', s.title);
+  addLit(SCHEMA + 'description', s.description ?? s.summary);
+  addLit(P + 'severity', s.severity);
+  addLit(P + 'source', s.source);
+  addLit(P + 'contributor', s.contributor);
+  addLit(P + 'family', s.family);
+  for (const t of s.tags ?? []) addLit(P + 'tag', t);
+  for (const r of s.references ?? []) addLit(SCHEMA + 'citation', r);
+
+  if (s.type === 'dependency') {
+    addLit(P + 'ecosystem', s.ecosystem);
+    addLit(P + 'package', s.package);
+    addLit(P + 'version', s.version);
+    addLit(P + 'kind', s.kind);
+    addLit(P + 'advisoryId', s.advisoryId);
+  } else if (s.type === 'ioc') {
+    addLit(P + 'iocType', s.ioc_type);
+    addLit(P + 'value', s.value);
+    addLit(P + 'threat', s.threat);
+    addLit(P + 'malware', s.malware);
+    if (s.confidence !== undefined) addLit(P + 'confidence', String(s.confidence));
+    addLit(P + 'firstSeen', s.first_seen); // plain string on purpose — see header
+  } else if (s.type === 'injection' || s.type === 'skill') {
+    addLit(P + 'pattern', s.pattern);
+    addLit(P + 'owasp', s.owasp);
+  }
+  return q;
+}
+
+/**
+ * Extract the flat record list from your source file. The example understands
+ * the Blackbox seed-bundle shape ({dependencies, injection, skills, iocs});
+ * replace with whatever your source looks like (or just `return json` for a
+ * plain array).
+ */
+export function extractRecords(json) {
+  if (Array.isArray(json)) return json;
+  return [
+    ...(json.injection ?? []),
+    ...(json.skills ?? []),
+    ...(json.dependencies ?? []),
+    ...(json.iocs ?? []),
+  ];
+}

--- a/scripts/dkg-kc-publisher/publish.mjs
+++ b/scripts/dkg-kc-publisher/publish.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Batched Knowledge-Collection publisher for a DKG V10 edge node (Base
+ * mainnet). One PAID on-chain mint per batch anchors ALL records in that
+ * batch as individually-addressable knowledge assets — this is the cost
+ * lever: gas is per-transaction, TRAC is per-byte×epoch.
+ *
+ * Flow per batch:  create+seal+share KA (free, off-chain)  →  vm/publish (PAID).
+ *
+ * Safety rails:
+ *  - refuses to run unless the node reports the expected network
+ *  - resumable ledger (registry.json): a batch with a txHash is never re-paid;
+ *    a sealed-but-unminted batch resumes at the mint step
+ *  - transient pre-flight failures (chain policy-read timeouts) retry
+ *    bounded; the tx is only signed after pre-flight passes, so those retries
+ *    are free — but see README about NOT hammering retries when the store is
+ *    the bottleneck
+ *
+ * Config via env:
+ *   DKG_ENDPOINT   default http://127.0.0.1
+ *   DKG_PORT       default 9200
+ *   DKG_AUTH_TOKEN_PATH  default ~/.dkg-mainnet/auth.token
+ *   KC_NETWORK     expected node networkConfig, default mainnet-base
+ *   KC_CG_ID       context graph id, default my-collection
+ *   KC_CG_NAME     display name, default = KC_CG_ID
+ *   KC_EPOCHS      storage epochs (30 days each), default 1
+ *   KC_ATTEMPTS    max vm/publish attempts per batch, default 3
+ *   KC_KA_PREFIX   KA name prefix, default = KC_CG_ID
+ *
+ * Usage:
+ *   node publish.mjs --dry-run           # build + validate quads, no writes
+ *   node publish.mjs                     # all unpublished batches, in order
+ *   node publish.mjs --batch batch-001   # one batch
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { recordQuads } from './mapping.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BASE = `${process.env.DKG_ENDPOINT ?? 'http://127.0.0.1'}:${process.env.DKG_PORT ?? '9200'}`;
+const NETWORK = process.env.KC_NETWORK ?? 'mainnet-base';
+const CG_ID = process.env.KC_CG_ID ?? 'my-collection';
+const CG_NAME = process.env.KC_CG_NAME ?? CG_ID;
+const EPOCHS = Number(process.env.KC_EPOCHS ?? '1');
+const ATTEMPTS = Number(process.env.KC_ATTEMPTS ?? '3');
+const KA_PREFIX = process.env.KC_KA_PREFIX ?? CG_ID;
+const TOKEN_PATH = process.env.DKG_AUTH_TOKEN_PATH ?? join(homedir(), '.dkg-mainnet', 'auth.token');
+const LEDGER = join(here, 'registry.json');
+
+const argv = process.argv.slice(2);
+const DRY = argv.includes('--dry-run');
+const only = argv.includes('--batch') ? argv[argv.indexOf('--batch') + 1] : null;
+
+const authToken = readFileSync(TOKEN_PATH, 'utf8').split('\n').map((l) => l.trim()).find((l) => l && !l.startsWith('#'));
+
+async function api(method, path, body, timeoutMs = 60_000) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${authToken}` },
+    body: body === undefined ? undefined : JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await res.text();
+  let json; try { json = JSON.parse(text); } catch { json = { raw: text }; }
+  if (!res.ok) { const e = new Error(`${res.status} ${path}: ${json.error ?? text.slice(0, 400)}`); e.body = json; throw e; }
+  return json;
+}
+
+const ledger = existsSync(LEDGER) ? JSON.parse(readFileSync(LEDGER, 'utf8')) : { cg: null, batches: {} };
+const saveLedger = () => writeFileSync(LEDGER, JSON.stringify(ledger, null, 2));
+
+async function main() {
+  const status = await api('GET', '/api/status');
+  if (status.networkConfig !== NETWORK) {
+    throw new Error(`refusing: node at ${BASE} is "${status.name}" (${status.networkConfig}), expected ${NETWORK}`);
+  }
+  console.log(`node OK: ${status.name} ${status.networkName} peers=${status.connectedPeers}`);
+
+  const batchFiles = readdirSync(join(here, 'batches')).filter((f) => f.endsWith('.json')).sort()
+    .filter((f) => !only || f === `${only}.json`);
+  if (!batchFiles.length) throw new Error('no batch files — run chunk.mjs first');
+
+  // Build + validate quads up front (cheap, catches mapping bugs before spending).
+  const prepared = [];
+  for (const f of batchFiles) {
+    const { name, records } = JSON.parse(readFileSync(join(here, 'batches', f), 'utf8'));
+    const quads = records.flatMap(recordQuads);
+    for (const q of quads) {
+      if (q.object.length > 60_000) throw new Error(`${name}: oversize literal on ${q.subject} ${q.predicate} (${q.object.length}B)`);
+      if (!q.object.startsWith('"') && !/^[a-z][a-z0-9+.-]*:/i.test(q.object)) throw new Error(`${name}: object not IRI/literal: ${q.object.slice(0, 80)}`);
+    }
+    const bytes = JSON.stringify(quads).length;
+    console.log(`${name}: ${records.length} records -> ${quads.length} quads, ~${(bytes / 1e6).toFixed(2)} MB payload`);
+    if (bytes > 9_000_000) throw new Error(`${name}: payload exceeds the node's ~10MB request cap — use a smaller --size`);
+    prepared.push({ name, quads });
+  }
+  if (DRY) { console.log('dry-run: no writes performed'); return; }
+
+  // Ensure the context graph exists (free, local; on-chain registration —
+  // and its ~100 TRAC deposit — happens automatically on the first mint).
+  const exists = await api('GET', `/api/context-graph/exists?id=${encodeURIComponent(CG_ID)}`).catch(() => null);
+  if (exists?.exists) {
+    ledger.cg = CG_ID;
+  } else if (!ledger.cg) {
+    const created = await api('POST', '/api/context-graph/create', { id: CG_ID, name: CG_NAME, description: `${CG_NAME} — batched knowledge-collection publishing.` });
+    ledger.cg = created.id ?? CG_ID;
+    console.log('created CG:', JSON.stringify(created).slice(0, 200));
+  }
+  saveLedger();
+  console.log('context graph:', ledger.cg);
+
+  for (const { name, quads } of prepared) {
+    const rec = (ledger.batches[name] ??= {});
+    const kaName = `${KA_PREFIX}-${name}`;
+
+    if (rec.txHash) { console.log(`[${name}] already published: ${rec.ual}`); continue; }
+
+    if (!rec.sealed) {
+      console.log(`[${name}] create+seal+share KA "${kaName}" (${quads.length} quads)...`);
+      const r = await api('POST', '/api/knowledge-assets', {
+        contextGraphId: ledger.cg, name: kaName, quads, finalize: true, alsoShareSwm: true,
+      }, 600_000);
+      if (Array.isArray(r.errors) && r.errors.length) throw new Error(`[${name}] phase errors: ${JSON.stringify(r.errors).slice(0, 500)}`);
+      rec.sealed = true;
+      saveLedger();
+      console.log(`[${name}] sealed + shared`);
+    }
+
+    console.log(`[${name}] PAID vm/publish (epochs=${EPOCHS}) — one on-chain tx...`);
+    let r;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        r = await api('POST', `/api/knowledge-assets/${encodeURIComponent(kaName)}/vm/publish`, {
+          contextGraphId: ledger.cg, options: { publishEpochs: EPOCHS },
+        }, 600_000);
+        break;
+      } catch (e) {
+        // "not a complete full share" after a node restart → discard + reseal.
+        if (/not a complete full share/i.test(e.message)) {
+          console.log(`[${name}] stale SWM share — discarding + resealing...`);
+          await api('POST', `/api/knowledge-assets/${encodeURIComponent(kaName)}/wm/discard`, { contextGraphId: ledger.cg }, 120_000).catch(() => {});
+          rec.sealed = false; saveLedger();
+          const rr = await api('POST', '/api/knowledge-assets', {
+            contextGraphId: ledger.cg, name: kaName, quads, finalize: true, alsoShareSwm: true,
+          }, 600_000);
+          if (Array.isArray(rr.errors) && rr.errors.length) throw new Error(`[${name}] reseal phase errors: ${JSON.stringify(rr.errors).slice(0, 500)}`);
+          rec.sealed = true; saveLedger();
+          continue;
+        }
+        const transient = /access-policy is unknown|timed out|timeout|fetch failed/i.test(e.message);
+        if (!transient || attempt >= ATTEMPTS) throw e;
+        console.log(`[${name}] transient pre-flight failure (attempt ${attempt}/${ATTEMPTS}), retrying in 15s: ${e.message.slice(0, 120)}`);
+        await new Promise((res) => setTimeout(res, 15_000));
+      }
+    }
+    Object.assign(rec, { kaId: r.kaId, ual: r.ual, txHash: r.txHash, blockNumber: r.blockNumber, status: r.status, epochs: EPOCHS });
+    saveLedger();
+    console.log(`[${name}] MINTED ual=${r.ual} tx=${r.txHash} block=${r.blockNumber} status=${r.status}`);
+  }
+
+  console.log('\nDone. Ledger:', LEDGER);
+}
+
+main().catch((e) => { console.error('FATAL:', e.message); process.exit(1); });

--- a/scripts/dkg-kc-publisher/rpc-proxy.mjs
+++ b/scripts/dkg-kc-publisher/rpc-proxy.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Local caching JSON-RPC proxy for Base mainnet — shields the DKG node from
+ * public-RPC rate limits (429s) that blow its hard-coded 2.5s chain-read
+ * budget.
+ *
+ *  - short-TTL cache for READ-ONLY methods only (eth_call, blockNumber, ...);
+ *    tx submission, nonces, gas estimates are ALWAYS forwarded fresh
+ *  - in-flight dedup: identical concurrent reads share one upstream request
+ *  - upstream rotation with per-endpoint cooldown on 429/5xx/timeouts
+ *
+ * Listens on 127.0.0.1:8547. Point the node's chain.rpcUrl here.
+ */
+import { createServer } from 'node:http';
+
+const PORT = 8547;
+const UPSTREAMS = [
+  'https://base.drpc.org',
+  'https://base-rpc.publicnode.com',
+  'https://mainnet.base.org',
+  'https://base.meowrpc.com',
+];
+
+// method -> cache TTL ms. Anything not listed is never cached.
+const CACHE_TTL = {
+  eth_chainId: 3_600_000,
+  net_version: 3_600_000,
+  eth_blockNumber: 2_000,
+  eth_call: 15_000,
+  eth_getCode: 300_000,
+  eth_getLogs: 5_000,
+  eth_getBlockByNumber: 5_000,
+  eth_feeHistory: 5_000,
+  eth_gasPrice: 5_000,
+  eth_maxPriorityFeePerGas: 5_000,
+};
+
+const cache = new Map();      // key -> { expires, value }
+const inflight = new Map();   // key -> Promise
+const cooldown = new Map();   // upstream -> notBeforeTs
+
+async function callUpstream(payload) {
+  const body = JSON.stringify(payload);
+  let lastErr;
+  for (let round = 0; round < 2; round++) {
+    for (const u of UPSTREAMS) {
+      if ((cooldown.get(u) ?? 0) > Date.now()) continue;
+      try {
+        const res = await fetch(u, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body,
+          signal: AbortSignal.timeout(8_000),
+        });
+        if (res.status === 429 || res.status >= 500) {
+          cooldown.set(u, Date.now() + 20_000);
+          lastErr = new Error(`${u}: HTTP ${res.status}`);
+          continue;
+        }
+        const json = await res.json();
+        // JSON-RPC-level throttle answers also mean "rotate"
+        if (json?.error && /too many|rate|limit/i.test(String(json.error.message ?? ''))) {
+          cooldown.set(u, Date.now() + 20_000);
+          lastErr = new Error(`${u}: rpc throttle: ${json.error.message}`);
+          continue;
+        }
+        return json;
+      } catch (e) {
+        cooldown.set(u, Date.now() + 10_000);
+        lastErr = e;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw lastErr ?? new Error('all upstreams failed');
+}
+
+async function handleOne(req) {
+  const ttl = CACHE_TTL[req.method];
+  if (!ttl) {
+    const r = await callUpstream(req);
+    return { ...r, id: req.id };
+  }
+  const key = `${req.method}:${JSON.stringify(req.params ?? [])}`;
+  const hit = cache.get(key);
+  if (hit && hit.expires > Date.now()) return { ...hit.value, id: req.id };
+  if (inflight.has(key)) {
+    const value = await inflight.get(key);
+    return { ...value, id: req.id };
+  }
+  const p = (async () => {
+    const value = await callUpstream(req);
+    if (!value.error) cache.set(key, { expires: Date.now() + ttl, value });
+    return value;
+  })();
+  inflight.set(key, p);
+  try {
+    const value = await p;
+    return { ...value, id: req.id };
+  } finally {
+    inflight.delete(key);
+  }
+}
+
+const server = createServer((req, res) => {
+  if (req.method !== 'POST') { res.writeHead(405).end(); return; }
+  let body = '';
+  req.on('data', (c) => { body += c; });
+  req.on('end', async () => {
+    try {
+      const parsed = JSON.parse(body);
+      const out = Array.isArray(parsed)
+        ? await Promise.all(parsed.map(handleOne))
+        : await handleOne(parsed);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(out));
+    } catch (e) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      const id = (() => { try { return JSON.parse(body)?.id ?? null; } catch { return null; } })();
+      res.end(JSON.stringify({ jsonrpc: '2.0', id, error: { code: -32603, message: `proxy: ${e.message}` } }));
+    }
+  });
+});
+
+server.listen(PORT, '127.0.0.1', () => console.log(`base rpc proxy on http://127.0.0.1:${PORT} -> ${UPSTREAMS.length} upstreams`));


### PR DESCRIPTION
## What

Adds `scripts/dkg-kc-publisher/` — a dependency-free toolkit (Node >= 20, no npm installs) for publishing large signal datasets to the OriginTrail DKG (V10, Base mainnet) as **batched knowledge collections**: one on-chain transaction per ~1,000 records instead of one per record. Every record remains an individually-addressable, SPARQL-queryable knowledge asset inside its collection.

## Why

Gas is per *transaction*; TRAC is per *byte x epoch*. Batching collapses the gas side ~1,000x while leaving TRAC unchanged. Measured on Base mainnet against the `prod-threats-400k` seed bundle (two 1,000-signal collections minted into CG `defender`, txs `0x8cb39a2b...` / `0xe8201fbf...`):

- **~1.1 TRAC + negligible gas** per 1,000-signal collection (1 epoch)
- one-time ~100 TRAC RFC-53 deposit at first mint on a new CG
- full 460k bundle extrapolates to ~460 txs = **<$1 of ETH + ~510 TRAC/epoch** (vs ~$5-14k gas per-record style)

## Files

| File | Purpose |
|---|---|
| `mapping.mjs` | record -> key + RDF quads — the adaptation point (ships with the threat-signal schema as the worked example) |
| `chunk.mjs` | source file -> globally-deduplicated `batches/batch-NNN.json` (Rule-4 safe) |
| `publish.mjs` | CG ensure -> seal/share -> one paid mint per batch; resumable ledger, network guard, dry-run validation, auto-recovery for stale-share 409s |
| `rpc-proxy.mjs` | local caching Base-RPC proxy — fixes LU-5/LU-11 publish refusals caused by public-RPC throttling vs the node's 2.5s chain-read budget |
| `README.md` | runbook: quick start, cost model, sizing, and 7 operational gotchas hit during the live probe |

## Testing

- `chunk.mjs` + `publish.mjs --dry-run` validated against the live Base-mainnet okf node with the real 460k bundle (3 probe batches: ~12k quads / ~2 MB each, 10,170 source duplicates correctly skipped).
- The un-generalized ancestor of these scripts minted both probe collections on Base mainnet; content verified queryable via `/api/query` SPARQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xfGEp2sDzLtmSEtb8XTvG
