### PR TITLE
Fix Blackbox installer checkout recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,8 @@ The installer adds `blackbox` as a shortcut for `hermes blackbox`.
 `blackbox chat` opens a dedicated operator chat for Blackbox without adding that
 chat to the protected-agent count.
 
-Found a threat yourself? Report it to the community graph so every agent sees it:
-
-```bash
-# a malicious npm package
-blackbox report --type dependency --ecosystem npm \
-  --name evil-package --version 1.0.0 --severity critical
-
-# a prompt-injection pattern
-blackbox report --type injection \
-  --pattern "ignore all previous instructions" --owasp LLM01
-```
+The community graph and threat sharing are shown as **Coming soon**. For now,
+findings and reports stay local and `blackbox report` submits nothing.
 
 Ready to enforce instead of just watch? Flip block mode in `config.yaml`:
 
@@ -140,7 +131,7 @@ plugins:
       mode: block   # stop confirmed threats instead of only flagging them
 ```
 
-Every detection is logged to the audit trail and shown live in the dashboard. Eligible findings can also be shared as privacy-safe community reports.
+Every detection is logged locally to the audit trail and shown live in the dashboard.
 
 The reviewer only flags - it never blocks, and its verdicts stay on your machine (never shared to the community graph). Turn it off with `blackbox setup-llm --disable`.
 
@@ -186,18 +177,17 @@ Threats should not have to be rediscovered one agent at a time. Agent Blackbox
 gives every protected agent the benefit of what the network has already learned:
 
 - **Verified** threats are reviewed by Umanitek and can be blocked.
-- **Community** reports warn other agents while they await verification.
+- **Community** Shared Working Memory is coming soon and is not used yet.
 - **Local** findings stay available in your own dashboard and audit trail.
 
 ## How it works
 
 1. **Watch.** Blackbox sees the prompt, tool call, command, file, package, or
    skill before the agent acts.
-2. **Check.** It compares the action with built-in security rules and shared
-   threat intelligence.
+2. **Check.** It compares the action with built-in security rules and the
+   curated public Verifiable Memory graph.
 3. **Respond.** Audit mode warns and records. Block mode stops confirmed threats.
-4. **Learn.** Eligible high-severity findings can become privacy-safe community
-   reports, helping other agents spot the same attack.
+4. **Record.** Findings remain in the user's local audit trail.
 
 ### Under the hood
 
@@ -205,9 +195,9 @@ The shared intelligence lives on the OriginTrail Decentralized Knowledge Graph
 (DKG). Blackbox runs its own isolated local DKG node, so it does not replace or
 modify another DKG installation.
 
-The threat graph is private: approved nodes can read its threat data, while its
-anchors remain publicly verifiable. Verified public threats are the only shared
-threats allowed to block; community reports warn until they are reviewed.
+The curated threat graph is public and requires no private membership or join
+approval. Only its verified VM content is used for threat matching. Community
+SWM and threat sharing remain visible as coming-soon features but are inactive.
 
 The dashboard shows **Public**, **Community**, and **Local** intelligence side by
 side. Technical settings, paths, and node details are listed below.
@@ -240,8 +230,8 @@ Set under `plugins.entries.blackbox.*` in `config.yaml`.
 | `dkg_home` | `<agent-blackbox>/.dkg` | isolated DKG node config, token, pid, and cache |
 | `context_graph_id` | `0x37b1Fdfd…/agent-blackbox-vm` | Public verified threat graph |
 | `graph_peer_id` | bundled publisher peer | Authoritative threat-data sync source |
-| `daily_report_limit` | `9999` | max threat reports sent to the community graph per day |
-| `report_min_severity` | `high` | minimum severity for heuristic candidates to be flagged and reported |
+| `report` | `false` | fixed off while community threat sharing is coming soon |
+| `report_min_severity` | `high` | reserved for future community sharing; does not submit today |
 | `detection.<category>.enabled` | `true` | turn a whole category on/off (`injection`, `escalation`, `dependency`, `fileaccess`, `skill`) |
 | `detection.<category>.min_severity` | `info` | quiet a category below this level, e.g. `detection.dependency.min_severity: critical` |
 | `protected_paths` | `[]` | your own files/folders that always block and never leave your machine |

--- a/plugins/blackbox/README.md
+++ b/plugins/blackbox/README.md
@@ -71,18 +71,17 @@ plugins:
 
 ## How threat data works
 
-Blackbox uses two shared graphs:
+Blackbox currently uses one shared graph:
 
 - The **public graph** contains Umanitek-verified threats. These can be blocked
   in block mode. Anyone can read and sync it, while publishing remains curated.
   The UI expands collection contents and lists each threat entity, not one row
   per collection.
-- The **community graph** contains reports awaiting review. These warn but
-  never block.
+- The **community graph** (SWM) is shown as **Coming soon**. It is not queried,
+  joined, matched, or written in the current release.
 
 Raw prompts, commands, file contents, secrets, and your local audit trail are
-not published to either graph. Reports use deterministic identifiers instead
-of the observed private content.
+not published. Findings and reports stay local.
 
 ## Configuration
 
@@ -93,8 +92,8 @@ to change them is through the dashboard settings page.
 |---|---:|---|
 | `mode` | `audit` | Warn only (`audit`) or stop confirmed threats (`block`) |
 | `block_severity` | `critical` | Minimum severity blocked in block mode |
-| `report` | `true` | Share eligible threat reports with the community graph |
-| `report_min_severity` | `high` | Minimum severity shared as a report |
+| `report` | `false` | Fixed off while community threat sharing is coming soon |
+| `report_min_severity` | `high` | Reserved for future community sharing |
 | `detection.<category>.enabled` | `true` | Enable or disable a detection category |
 | `detection.<category>.min_severity` | `info` | Minimum visible severity for a category |
 | `protected_paths` | `[]` | Local file globs that always block and are never shared |

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -26,12 +26,6 @@ _BLACKBOX_SOUL_MARKER = "<!-- managed-by: hermes-blackbox-chat -->"
 _LEGACY_GUARDIAN_SOUL_MARKER = "<!-- managed-by: hermes-guardian-chat -->"
 _BLACKBOX_SOURCE_ROOT_MARKER = ".blackbox-source-root"
 _BLACKBOX_CONTEXT_FILE_MAX_CHARS = 100_000
-# The release graph is public. Keep the private-join machinery available for
-# the previous private graph without making public installs request curator
-# membership.
-_PRIVATE_AUTO_JOIN_GRAPH_IDS: frozenset[str] = frozenset({
-    "0x37b1Fdfd134e2b17583bCBdD3034F91504cD9C70/agent-blackbox",
-})
 _BLACKBOX_SOUL = f"""{_BLACKBOX_SOUL_MARKER}
 # Agent Blackbox
 
@@ -46,11 +40,11 @@ questions from general knowledge. If asked "what's in the public/community/local
 graph", "what threats do we know", "recent activity", "connected agents", etc.,
 you MUST fetch the real data from the sources below and answer from that.
 
-## The three tiers (know the difference)
-- **Public** (on-chain, verifiable memory): the Umanitek-verified threat graph.
+## Graph scope
+- **Public** (on-chain, verifiable memory): the Umanitek-curated threat graph.
   Confirmed threats that BLOCK in block mode. Field name in APIs: `curated`.
-- **Community** (shared working memory / SWM): an open pool any agent reports
-  into. Flags only, never blocks. Field name: `community`.
+- **Community** (shared working memory / SWM): coming soon. It is not queried,
+  matched, joined, or written in this release. Findings stay local.
 - **Local** (this node's working memory + synced ruleset): what THIS node has
   pulled down and what it detects with offline. Field name: `ruleset`.
 
@@ -59,12 +53,12 @@ Prefer the running dashboard API on http://127.0.0.1:9700 (all read-only, JSON):
 
 - `GET /api/graph-status` — counts + config. Returns `mode`, `context_graph_id`,
   `dkg_url`, `node_reachable`, `last_sync`, `ruleset` (per-category local counts),
-  `curated` (Public tier count), `community` (Community/SWM count),
+  `curated` (Public tier count), `community` (always 0 / coming soon),
   `sightings`, `findings_logged`.
-- `GET /api/graph?tier=public|community|local` — the actual threat ENTRIES for a
+- `GET /api/graph?tier=public|local` — the actual threat ENTRIES for a
   tier. Returns `{{tier, threats:[{{identifier, category, severity, name}}]}}`.
   Use this to list what's in the public/community/local graph.
-- `GET /api/threat?tier=public|community&identifier=<id>` — full detail for one
+- `GET /api/threat?tier=public&identifier=<id>` — full detail for one
   threat (description, references/advisories, reporters).
 - `GET /api/findings?limit=&offset=` — threats Blackbox has flagged on this
   machine (newest first) with total.
@@ -72,7 +66,7 @@ Prefer the running dashboard API on http://127.0.0.1:9700 (all read-only, JSON):
   lifecycle, API requests, tool calls with the real command, installs, flags).
 - `GET /api/agents` — connected/protected local agents. Count the `agents` array
   EXACTLY; never estimate from generic Hermes status or sessions.
-- `GET /api/reports` — recent outbound sightings shared to the community graph.
+- `GET /api/reports` — returns the community-feature coming-soon state.
 
 If the dashboard is NOT running (curl to :9700 fails), fall back to:
 - `hermes blackbox status` — mode, node reachability, ruleset + findings counts.
@@ -151,7 +145,7 @@ def setup_cli(parser: argparse.ArgumentParser) -> None:
     detach_p.add_argument("--openclaw-only", action="store_true", help="Only detach from OpenClaw workspaces")
     detach_p.set_defaults(func=_cmd_detach)
 
-    report = sub.add_parser("report", help="Submit a NEW candidate threat to the community graph (SWM)")
+    report = sub.add_parser("report", help="Community threat sharing (coming soon; submits nothing)")
     report.add_argument(
         "--type", required=True,
         choices=["injection", "escalation", "dependency", "fileaccess", "skill"],
@@ -732,10 +726,11 @@ def _cmd_sync(args: argparse.Namespace) -> int:
     print(f"Ruleset synced from {cfg.context_graph_id}:")
     print(f"  {counts['injection']} injection, {counts['escalation']} escalation, "
           f"{counts['dependency']} dependency")
-    print(f"  {public_count:,} public VM, {community_count:,} community SWM")
+    print(f"  {public_count:,} public VM (curated)")
+    print("  Community graph (SWM): coming soon")
     if not sync_complete:
         if private_graph and (pending_approval or not subscribed):
-            print("  Pending curator approval; private VM/SWM data is not available yet.")
+            print("  This graph is not supported; Agent Blackbox only uses its public VM graph.")
             if agent_address:
                 print(f"  Ask the curator to approve agent address: {agent_address}")
             if last_subscribe_error:
@@ -749,14 +744,11 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         }:
             detail = last_catchup.get("error") or (last_catchup.get("result") or {}).get("error")
             print(f"  Fresh DKG catch-up failed{f': {detail}' if detail else '.'}")
-        elif managed_graph and community_count > 0 and public_count == 0:
-            print("  Community SWM synced, but public VM is still empty.")
-            print("  Retry with `hermes blackbox sync --wait`.")
         elif authoritative_attempted and not authoritative_complete:
             print("  Authoritative curator VM transfer is incomplete.")
             print("  Retry with `hermes blackbox sync --wait`.")
         else:
-            print("  0 rules — DKG has not made VM/SWM threat rows queryable yet.")
+            print("  0 rules — DKG has not made curated VM threat rows queryable yet.")
             print("  Retry with `hermes blackbox sync --wait`.")
         if getattr(args, "require_rules", False):
             print("  Required ruleset sync is incomplete.")
@@ -913,10 +905,8 @@ def _catchup_job_id(catchup: Any) -> str:
 
 
 def _should_request_private_join(cfg: BlackboxConfig) -> bool:
-    return bool(
-        getattr(cfg, "graph_peer_id", "")
-        and getattr(cfg, "context_graph_id", "") in _PRIVATE_AUTO_JOIN_GRAPH_IDS
-    )
+    """Private graph membership is never part of Agent Blackbox."""
+    return False
 
 
 def _request_join(client: DkgClient, cg_id: str, graph_peer_id: str) -> tuple[Optional[str], bool]:
@@ -1035,31 +1025,9 @@ def _print_openclaw_attach_row(row: Dict[str, Any], prefix: str) -> None:
 
 
 def _cmd_report(args: argparse.Namespace) -> int:
-    cfg = load_blackbox_config()
-    client = DkgClient(url=cfg.dkg_url, dkg_home=cfg.dkg_home)
-    try:
-        identifier, quad_kwargs = _build_candidate(args)
-    except ValueError as exc:
-        print(f"error: {exc}")
-        return 2
-    reporter = _resolve_reporter(client)
-    q = quads.build_report_quads(
-        identifier=identifier,
-        category=args.type,
-        severity=args.severity,
-        reporter_address=reporter,
-        framework="hermes",
-        **quad_kwargs,
-    )
-    name = f"report-{quads.stable_hash(identifier + reporter, 16)}"
-    try:
-        client.share_knowledge_asset(cfg.context_graph_id, name, q)
-    except DkgError as exc:
-        print(f"error: failed to share report: {exc}")
-        return 1
-    print(f"Reported candidate threat: {identifier}")
-    print(f"  shared to {cfg.context_graph_id} (SWM) as reporter {reporter}")
-    return 0
+    print("Community graph and threat sharing are coming soon.")
+    print("Nothing was submitted; findings and threat reports stay local.")
+    return 2
 
 
 def _cmd_dashboard(args: argparse.Namespace) -> int:

--- a/plugins/blackbox/config.py
+++ b/plugins/blackbox/config.py
@@ -103,7 +103,7 @@ class BlackboxConfig:
     dkg_home: str = field(default_factory=lambda: str(constants.blackbox_dkg_home()))
     dkg_bin: str = field(default_factory=lambda: str(constants.blackbox_dkg_bin()))
     sync_interval: int = 60
-    report: bool = True
+    report: bool = False
     daily_report_limit: int = 9999
     report_min_severity: str = "high"
     block_severity: str = "critical"
@@ -313,7 +313,9 @@ def load_blackbox_config() -> BlackboxConfig:
         sync_interval=_as_int(
             _env_or(entry, env="BLACKBOX_SYNC_INTERVAL", key="sync_interval", default=60), 60
         ),
-        report=_as_bool(_env_or(entry, env="BLACKBOX_REPORT", key="report", default=True), True),
+        # Threat sharing ships with the future community graph. This is not a
+        # user-toggleable path in the VM-only release.
+        report=False,
         daily_report_limit=_as_int(
             _env_or(
                 entry,

--- a/plugins/blackbox/constants.py
+++ b/plugins/blackbox/constants.py
@@ -119,6 +119,11 @@ VIEW_WORKING_MEMORY = "working-memory"
 VIEW_SHARED_WORKING_MEMORY = "shared-working-memory"
 VIEW_VERIFIABLE_MEMORY = "verifiable-memory"
 
+# Community graph ingestion and outbound threat sharing are intentionally not
+# part of the current release. Keep this compile-time closed until the complete
+# SWM trust and consent model ships; user configuration must not reopen it.
+COMMUNITY_GRAPH_ENABLED = False
+
 
 def normalize_severity(value: object, fallback: str = "info") -> str:
     """Coerce an arbitrary value to a known severity string.

--- a/plugins/blackbox/dashboard/server.py
+++ b/plugins/blackbox/dashboard/server.py
@@ -189,24 +189,50 @@ def _graph_entries(rs: Any, source: str) -> List[Dict[str, Any]]:
 
 def _ruleset_sync_counts(rs: Any) -> Dict[str, int]:
     public = _graph_source_count(rs, "public")
-    community = _graph_source_count(rs, "community")
-    graph_total = public + community
     return {
-        "total": max(_ruleset_total(rs), graph_total),
+        "total": max(_ruleset_total(rs), public),
         "public": public,
-        "community": community,
+        "community": 0,
     }
 
 
 def _sync_ruleset_once(load_config: Any, dkg_client_cls: Any, ruleset_mod: Any) -> Dict[str, int]:
-    """Connect through DKG, then refresh the VM/SWM ruleset."""
+    """Subscribe to the public graph and refresh its curated VM rules."""
     cfg = load_config()
     transfer = sync_state.read()
     if transfer.get("status") == "running":
         public = int(transfer.get("public_entries") or 0)
-        community = int(transfer.get("community_entries") or 0)
-        return {"total": public + community, "public": public, "community": community}
+        return {"total": public, "public": public, "community": 0}
     client = dkg_client_cls(url=cfg.dkg_url, dkg_home=cfg.dkg_home)
+    # The release graph is public. Subscription never requires or attempts a
+    # private membership handshake.
+    try:
+        client.subscribe_context_graph(cfg.context_graph_id)
+        with _join_lock:
+            _connection_states[cfg.context_graph_id] = {
+                "state": "syncing",
+                "updated_at": time.time(),
+            }
+    except Exception as exc:
+        with _join_lock:
+            _connection_states[cfg.context_graph_id] = {
+                "state": "connection-error",
+                "updated_at": time.time(),
+                "error": str(exc),
+            }
+    rs = ruleset_mod.refresh(cfg, client)
+    counts = _ruleset_sync_counts(rs)
+    if counts["public"]:
+        with _join_lock:
+            _connection_states[cfg.context_graph_id] = {
+                "state": "subscribed",
+                "updated_at": time.time(),
+            }
+    return counts
+
+    # Legacy private-graph recovery code below is intentionally unreachable;
+    # retained temporarily to minimize the compatibility diff while the DKG
+    # client API is shared with other products.
     peer_id = str(getattr(cfg, "graph_peer_id", "") or "")
     if peer_id:
         try:
@@ -1164,7 +1190,7 @@ def create_app(*, manage_guardian: bool = False):
         # rows are complete threats, and ruleset.refresh also promotes any
         # still-unmigrated legacy proof rows.
         public = _graph_source_count(rs, "public")
-        community = _graph_source_count(rs, "community")
+        community = 0
 
         # Catch-up state must stay independent from the potentially expensive
         # SWM sightings COUNT. Otherwise a busy store can hide the live
@@ -1183,19 +1209,13 @@ def create_app(*, manage_guardian: bool = False):
                 "catchup": catchup,
             }
 
-        def _sightings() -> Any:
-            if not _node_reachable(cfg):
-                return None
-            client = DkgClient(url=cfg.dkg_url, dkg_home=cfg.dkg_home)
-            return ruleset.community_report_count(client, cfg)
-
         g = _swr(
             "graph-sync-status",
             _node_sync,
             {"node_reachable": False, "catchup": {}},
             ttl=4.0,
         )
-        sightings = _swr("graph-sightings", _sightings, 0)
+        sightings = 0
         total_rules = sum(int(v or 0) for v in counts.values())
         catchup = g.get("catchup") if isinstance(g.get("catchup"), dict) else {}
         node_catchup_state = str(catchup.get("status") or "")
@@ -1228,22 +1248,12 @@ def create_app(*, manage_guardian: bool = False):
                 ),
             )
         )
-        community_state = _graph_sync_state(
-            community,
-            g["node_reachable"],
-            node_catchup_state,
-            settled=(
-                authoritative_done
-                and node_catchup_state.lower() not in {"queued", "running"}
-            ),
-        )
+        community_state = "coming-soon"
         with _join_lock:
             connection = dict(_connection_states.get(cfg.context_graph_id) or {})
         if connection.get("state") in {"pending-approval", "pending-encryption-profile", "joining"}:
             if not public:
                 public_state = connection["state"]
-            if not community:
-                community_state = connection["state"]
         activity = _sync_activity(
             public=public,
             community=community,
@@ -1255,8 +1265,6 @@ def create_app(*, manage_guardian: bool = False):
         if activity["status"] in {"running", "waiting"}:
             if public_state == "empty":
                 public_state = "syncing"
-            if community_state == "empty":
-                community_state = "syncing"
 
         def _sync_label(tier: str, state: str) -> str:
             suffix = {
@@ -1267,6 +1275,7 @@ def create_app(*, manage_guardian: bool = False):
                 "pending-approval": "curator approval pending",
                 "pending-encryption-profile": "waiting for workspace encryption profile",
                 "joining": "joining private graph",
+                "coming-soon": "coming soon",
                 "sync-envelope-error": "peer sync handshake malformed",
             }.get(state, state)
             return f"{tier} {suffix}"
@@ -1294,7 +1303,7 @@ def create_app(*, manage_guardian: bool = False):
                 "community": {
                     "count": int(community or 0),
                     "state": community_state,
-                    "label": _sync_label("SWM", community_state),
+                    "label": "Community graph coming soon",
                 },
                 "catchup": {
                     "status": catchup_state or "idle",
@@ -1437,7 +1446,8 @@ def create_app(*, manage_guardian: bool = False):
                 reporters.append({"framework": fw, "address": str(addr), "count": n})
             return reporters
 
-        for rep in (_swr("agents-reporters", _load_reporters, []) or []):
+        # Remote SWM reporters are not part of the VM-only release.
+        for rep in []:
             fw, addr, n = rep["framework"], rep["address"], rep["count"]
             key = (fw, addr.lower())
             if key in found:
@@ -1605,7 +1615,7 @@ def create_app(*, manage_guardian: bool = False):
     def sync_graphs() -> Any:
         """Force an immediate ruleset refresh from the DKG node — the graph
         manual-refresh, same work as ``hermes blackbox sync``: subscribe/catch
-        up the public (VM) and community (SWM) graphs, then rebuild the local
+        up the curated public (VM) graph, then rebuild the local
         ruleset. Runs the exact path the background sync loop uses. The frontend
         re-polls /api/graph-status + /api/graph afterwards to redraw the counts.
         Fail-open: never 500s the dashboard."""
@@ -1625,7 +1635,7 @@ def create_app(*, manage_guardian: bool = False):
         """Map a UI tier name to a DKG SPARQL view.
 
         ``public`` → verifiable-memory (the curated source of truth),
-        ``community`` → shared-working-memory (the shared community pool),
+        ``community`` → coming soon (never queried),
         ``local`` → working-memory (this node's own private graph).
         """
         tier = (tier or default).lower()
@@ -1645,8 +1655,14 @@ def create_app(*, manage_guardian: bool = False):
         offset: int = Query(0, ge=0),
     ) -> Any:
         """Threats from one graph tier: ``public`` | ``community`` | ``local``."""
-        cfg = load_blackbox_config()
         tier, view = _tier_view(tier)
+        if tier == "community":
+            return {
+                "tier": "community", "threats": [], "total": 0,
+                "offset": offset, "limit": limit, "partial": False,
+                "coming_soon": True,
+            }
+        cfg = load_blackbox_config()
 
         def _category(identifier: str) -> str:
             ident = str(identifier or "")
@@ -1716,6 +1732,9 @@ def create_app(*, manage_guardian: bool = False):
 
     @app.get("/api/reports")
     def reports(limit: int = Query(50, ge=1, le=200)) -> Any:
+        return {"reports": [], "coming_soon": True, "sharing_enabled": False}
+
+        # Community reports are deliberately not queried in the VM-only release.
         cfg = load_blackbox_config()
 
         # Node-backed sightings list, served stale-while-revalidate.
@@ -1784,12 +1803,17 @@ def create_app(*, manage_guardian: bool = False):
     }
 
     @app.get("/api/threat")
-    def threat(identifier: str = Query(..., min_length=1), tier: str = Query("community")) -> Any:
+    def threat(identifier: str = Query(..., min_length=1), tier: str = Query("public")) -> Any:
         """Full detail for ONE threat via a targeted point-lookup.
 
         ``tier`` ∈ public | community | local. Fail-open."""
+        tier, view = _tier_view(tier, default="public")
+        if tier == "community":
+            return {
+                "identifier": identifier, "tier": "community", "found": False,
+                "coming_soon": True,
+            }
         cfg = load_blackbox_config()
-        tier, view = _tier_view(tier, default="community")
         prefix = identifier.split(":", 1)[0].lower() if ":" in identifier else ""
         category = prefix if prefix in ("dep", "injection", "escalation", "fileaccess", "skill", "ioc") else "other"
         if category == "dep":

--- a/plugins/blackbox/dashboard/static/index.html
+++ b/plugins/blackbox/dashboard/static/index.html
@@ -2893,10 +2893,10 @@
       <div class="stat roadmap">
         <div class="label">
           <svg class="s-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-          Community pool
+          Community graph
         </div>
         <div class="value"><span class="stat-soon">Coming soon</span></div>
-        <div class="meta">identifiers flagged by agents</div>
+        <div class="meta">shared working memory is not active yet</div>
       </div>
       <div class="stat roadmap">
         <div class="label">
@@ -2904,7 +2904,7 @@
           Threat sharing
         </div>
         <div class="value"><span class="stat-soon">Coming soon</span></div>
-        <div class="meta">sightings shared to graph</div>
+        <div class="meta">findings and reports stay local</div>
       </div>
       </div>
     </section>

--- a/plugins/blackbox/hooks.py
+++ b/plugins/blackbox/hooks.py
@@ -73,7 +73,7 @@ def _flag_worthy(cfg: BlackboxConfig, findings: List[detection.Finding]) -> List
 
 
 def _report_and_audit(cfg: BlackboxConfig, event: str, findings: List[detection.Finding], detail: Dict[str, Any]) -> None:
-    """Audit always; on findings write private audit KA + outbound SWM sighting."""
+    """Audit findings locally; never publish them to community SWM."""
     finding_dicts = [f.to_dict() for f in findings]
     audit.record(event=event, findings=finding_dicts or None, detail=detail)
     if not findings:
@@ -97,9 +97,8 @@ def _report_and_audit(cfg: BlackboxConfig, event: str, findings: List[detection.
         if client is not None:
             audit.mark_reported(identifier)
             audit.write_private_audit_ka(client, cfg.context_graph_id, event, finding)
-        # Outbound SWM sighting (never carries observed prompt/command text).
-        if cfg.report and client is not None and audit.allow_report(cfg.daily_report_limit):
-            _share_sighting(client, cfg, finding)
+        # Outbound sharing is closed until the community graph ships. Findings
+        # and their private audit evidence remain local.
 
 
 def _share_sighting(client: DkgClient, cfg: BlackboxConfig, finding: Dict[str, Any]) -> None:

--- a/plugins/blackbox/plugin.yaml
+++ b/plugins/blackbox/plugin.yaml
@@ -6,7 +6,7 @@ version: "1.0.0"
 # registers no tool backend — only the lifecycle hooks below — so the load path
 # is otherwise identical to a standalone plugin.
 kind: backend
-description: "Agent Blackbox — graph-driven agent security. Syncs a threat ruleset from the local OriginTrail DKG node (verified public threats + local graph) and matches every tool call and model request against it: prompt-injection patterns, privilege-escalation tool shapes, and vulnerable dependency installs. Audit mode by default (records findings, shares anonymized sightings to SWM); block mode refuses tool calls at/above a configured severity. Fail-open everywhere."
+description: "Agent Blackbox — graph-driven agent security. Syncs a threat ruleset from the curated public Verifiable Memory graph and matches every tool call and model request against it: prompt-injection patterns, privilege-escalation tool shapes, and vulnerable dependency installs. Audit mode records findings locally; block mode refuses tool calls at/above a configured severity. Community SWM and threat sharing are coming soon. Fail-open everywhere."
 author: Umanitek
 hooks:
   - pre_tool_call

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -1,15 +1,8 @@
 """Graph-synced rule cache.
 
-The :class:`Ruleset` is built entirely from DKG query results, merged from two
-tiers with strict precedence:
-
-* ``verifiable-memory`` (the verified public threat graph) → rules tagged
-  ``source: "public"``. The source of truth: matches are CONFIRMED and, in
-  block mode, blockable.
-* ``shared-working-memory`` (the community pool) → rules tagged
-  ``source: "community"``. Checked only when the public graph doesn't already
-  cover the identifier: matches are flagged but NEVER block — anyone can write
-  to the community pool, so it must not be able to stop tool calls.
+The :class:`Ruleset` is built only from the curated public
+``verifiable-memory`` graph. Community Shared Working Memory is a future
+feature and is neither queried nor matched by the current release.
 
 It is cached to ``$BLACKBOX_HOME/ruleset.json`` and refreshed lazily:
 :func:`get` returns the cached ruleset immediately and, if the cache is older
@@ -571,13 +564,14 @@ def _deserialize(data: Dict[str, Any]) -> Ruleset:
             compiled = re.compile(src, re.IGNORECASE)
         except re.error:
             continue
-        rs.injection.append({**rule, "pattern": compiled})
-    rs.escalation = list(data.get("escalation", []))
-    rs.dependency = dict(data.get("dependency", {}))
-    rs.fileaccess = list(data.get("fileaccess", []))
-    rs.skill = list(data.get("skill", []))
-    rs.ioc = dict(data.get("ioc", {}))
-    rs.graph_threats = list(data.get("graph_threats", []))
+        if rule.get("source", "public") == "public":
+            rs.injection.append({**rule, "pattern": compiled})
+    rs.escalation = [r for r in data.get("escalation", []) if r.get("source", "public") == "public"]
+    rs.dependency = {k: r for k, r in data.get("dependency", {}).items() if r.get("source", "public") == "public"}
+    rs.fileaccess = [r for r in data.get("fileaccess", []) if r.get("source", "public") == "public"]
+    rs.skill = [r for r in data.get("skill", []) if r.get("source", "public") == "public"]
+    rs.ioc = {k: r for k, r in data.get("ioc", {}).items() if r.get("source", "public") == "public"}
+    rs.graph_threats = [r for r in data.get("graph_threats", []) if r.get("source", "public") == "public"]
     return rs
 
 
@@ -657,20 +651,14 @@ _EMPTY_RULESET_RETRY_S = 30.0
 def refresh(config: Optional[BlackboxConfig] = None, client: Optional[DkgClient] = None) -> Ruleset:
     """Query the node, rebuild the ruleset, and persist it. Fail-open.
 
-    Merges the verified public graph (VM) with the community pool (SWM), fully
-    paginated (no cap). Fail-open is *per tier*: if one tier's query fails, that
-    tier's last-good rules are preserved instead of being wiped, so a transient
-    public-graph error can never silently drop every blockable rule. On total
+    Reads only the verified public graph (VM), fully paginated (no cap). If its
+    query fails, the last-good public rules are preserved. On total
     failure, returns the last-good cache or an empty ruleset — never raises.
     """
     global _memory_cache
     config = config or load_blackbox_config()
     client = client or DkgClient(url=config.dkg_url, dkg_home=config.dkg_home)
-    # Verified public graph first, then the community pool.
-    tiers = (
-        (constants.VIEW_VERIFIABLE_MEMORY, "public"),
-        (constants.VIEW_SHARED_WORKING_MEMORY, "community"),
-    )
+    tiers = ((constants.VIEW_VERIFIABLE_MEMORY, "public"),)
     fetched = {tier: _fetch_tier(client, config.context_graph_id, view) for view, tier in tiers}
 
     # An entirely empty store gets an early cache-expiry below. Subscription,
@@ -688,33 +676,16 @@ def refresh(config: Optional[BlackboxConfig] = None, client: Optional[DkgClient]
                 _memory_cache = existing
             return existing
 
-    # Backward compatibility: proof-era SWM rows whose batch root
-    # matches an old on-chain anchor are promoted to the blockable public tier.
-    # New rows arrive directly from the VM tier as complete threat assets.
-    # Fail-open — verification errors leave community rows flag-only.
-    verified: set = set()
-    community_rows = fetched.get("community")
-    if community_rows:
-        try:
-            verified = verified_identifiers(community_rows, _fetch_proofs(client, config.context_graph_id))
-        except Exception as exc:  # pragma: no cover - fail open
-            logger.debug("blackbox: proof verification failed: %s", exc)
     rows: List[Any] = []
     for tier, view_rows in fetched.items():
         if view_rows is None:  # a failed tier (fail-open handled below)
             continue
-        if tier == "community" and verified:
-            rows.extend(
-                (row, "public" if extract_binding(row.get("identifier")) in verified else "community")
-                for row in view_rows
-            )
-        else:
-            rows.extend((row, tier) for row in view_rows)
+        rows.extend((row, tier) for row in view_rows)
     rs = build_from_rows(rows)
     if empty_success:
         # A fresh node's subscribe/catch-up is async. Do not cache "0 rules" as
         # fresh for the full sync interval; retry soon so the dashboard updates
-        # shortly after SWM lands locally.
+        # shortly after VM lands locally.
         interval = max(1.0, float(config.sync_interval or 1))
         retry_after = min(_EMPTY_RULESET_RETRY_S, interval)
         rs.synced_at = time.time() - interval + retry_after

--- a/plugins/blackbox/settings.py
+++ b/plugins/blackbox/settings.py
@@ -87,7 +87,7 @@ def _validate(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
             else:
                 errors.append(f"invalid {key}: {payload[key]!r}")
 
-    for key in ("report", "discover", "osv_lookup"):
+    for key in ("discover", "osv_lookup"):
         if key in payload:
             if isinstance(payload[key], bool):
                 updates[key] = payload[key]

--- a/scripts/blackbox-install.ps1
+++ b/scripts/blackbox-install.ps1
@@ -38,14 +38,18 @@ $RepoUrl     = if ($env:BLACKBOX_REPO_URL)    { $env:BLACKBOX_REPO_URL }    else
 $RepoBranch  = if ($env:BLACKBOX_REPO_BRANCH) { $env:BLACKBOX_REPO_BRANCH } else { "main" }
 $HermesHome  = if ($env:HERMES_HOME)          { $env:HERMES_HOME }          else { "$env:USERPROFILE\.hermes" }
 # Keep the managed npm DKG package and state in the Agent Blackbox checkout. When
-# invoked from a clone, use that clone; when piped through iex, use the checkout
-# Resolve-Repo creates at BLACKBOX_INSTALL_DIR.
+# invoked from a clone, use that clone; when piped through iex, default to an
+# agent-blackbox child of the invocation directory. BLACKBOX_INSTALL_DIR remains
+# the explicit override.
 if ($env:BLACKBOX_INSTALL_DIR) {
     $DefaultRepoDir = $env:BLACKBOX_INSTALL_DIR
-} elseif (Test-Path "$env:USERPROFILE\agent-blackbox\.git") {
-    $DefaultRepoDir = "$env:USERPROFILE\agent-blackbox"
+} elseif (
+    (Test-Path "$(Get-Location)\pyproject.toml") -and
+    (Test-Path "$(Get-Location)\plugins\blackbox")
+) {
+    $DefaultRepoDir = [string](Get-Location)
 } else {
-    $DefaultRepoDir = "$env:USERPROFILE\agent-blackbox"
+    $DefaultRepoDir = Join-Path ([string](Get-Location)) "agent-blackbox"
 }
 if ($PSCommandPath) {
     $candidateRepoDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
@@ -767,6 +771,28 @@ print("switched" if switched else ("changed" if changed else "unchanged"))
 }
 
 # ── Locate (or fetch) the repo ──────────────────────────────────────────────
+function Test-BlackboxRepoCheckout {
+    param([string]$Path)
+    if (-not (Test-Path "$Path\.git")) { return $false }
+    if (-not (Test-Path "$Path\pyproject.toml")) { return $false }
+    if (-not (Test-Path "$Path\plugins\blackbox")) { return $false }
+    try {
+        & git -C $Path rev-parse --verify HEAD *> $null
+        return $LASTEXITCODE -eq 0
+    } catch {
+        return $false
+    }
+}
+
+function Move-BrokenBlackboxRepoAside {
+    param([string]$Path)
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $backup = "$Path.broken-$stamp-$PID"
+    Write-Warn2 "Existing install at $Path is incomplete or not an Agent Blackbox checkout."
+    Move-Item -LiteralPath $Path -Destination $backup
+    Write-Step "Preserved it at $backup"
+}
+
 function Resolve-Repo {
     $scriptDir = Split-Path -Parent $PSCommandPath
     if ($scriptDir) {
@@ -782,14 +808,24 @@ function Resolve-Repo {
         exit 1
     }
     $script:RepoDir = $DefaultRepoDir
-    if (Test-Path "$RepoDir\.git") {
+    if ((Test-Path $RepoDir) -and -not (Test-BlackboxRepoCheckout $RepoDir)) {
+        Move-BrokenBlackboxRepoAside $RepoDir
+    }
+    if (Test-BlackboxRepoCheckout $RepoDir) {
         Write-Step "Updating existing clone at $RepoDir"
-        git -C $RepoDir fetch --depth 1 origin $RepoBranch 2>$null
-        git -C $RepoDir checkout $RepoBranch 2>$null
-        git -C $RepoDir pull --ff-only 2>$null
+        & git -C $RepoDir fetch --depth 1 origin $RepoBranch
+        if ($LASTEXITCODE -ne 0) { throw "Could not fetch $RepoBranch from $RepoUrl" }
+        & git -C $RepoDir checkout $RepoBranch
+        if ($LASTEXITCODE -ne 0) { throw "Could not check out $RepoBranch in $RepoDir" }
+        & git -C $RepoDir pull --ff-only origin $RepoBranch
+        if ($LASTEXITCODE -ne 0) { throw "Could not fast-forward $RepoDir to origin/$RepoBranch" }
     } else {
         Write-Step "Cloning $RepoUrl -> $RepoDir"
-        git clone --depth 1 --branch $RepoBranch $RepoUrl $RepoDir
+        & git clone --depth 1 --branch $RepoBranch $RepoUrl $RepoDir
+        if ($LASTEXITCODE -ne 0) { throw "Could not clone $RepoUrl into $RepoDir" }
+    }
+    if (-not (Test-BlackboxRepoCheckout $RepoDir)) {
+        throw "$RepoDir is not a complete Agent Blackbox Python project"
     }
     Write-Ok "Repo ready at $RepoDir"
 }

--- a/scripts/blackbox-install.sh
+++ b/scripts/blackbox-install.sh
@@ -25,13 +25,14 @@ REPO_BRANCH="${BLACKBOX_REPO_BRANCH:-main}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # Keep the managed npm DKG package and node state inside the Agent Blackbox
 # checkout. For a local script this is the current repository; for curl | bash
-# it is the checkout the installer creates at BLACKBOX_INSTALL_DIR.
+# the default is ./agent-blackbox beneath the directory where the user invoked
+# the installer. BLACKBOX_INSTALL_DIR remains the explicit override.
 if [ -n "${BLACKBOX_INSTALL_DIR:-}" ]; then
     BLACKBOX_INSTALL_ROOT="$BLACKBOX_INSTALL_DIR"
-elif [ -e "$HOME/agent-blackbox/.git" ]; then
-    BLACKBOX_INSTALL_ROOT="$HOME/agent-blackbox"
+elif [ -f "$PWD/pyproject.toml" ] && [ -d "$PWD/plugins/blackbox" ]; then
+    BLACKBOX_INSTALL_ROOT="$PWD"
 else
-    BLACKBOX_INSTALL_ROOT="$HOME/agent-blackbox"
+    BLACKBOX_INSTALL_ROOT="$PWD/agent-blackbox"
 fi
 BLACKBOX_INSTALL_SCRIPT="${BASH_SOURCE[0]:-}"
 if [ -n "$BLACKBOX_INSTALL_SCRIPT" ] && [ -f "$BLACKBOX_INSTALL_SCRIPT" ]; then
@@ -729,6 +730,22 @@ fi
 
 # ── Locate (or fetch) the repo ──────────────────────────────────────────────
 # When run from a clone, use it in-place. When piped from curl, clone REPO_URL.
+blackbox_repo_is_valid() {
+    local repo="$1"
+    [ -d "$repo/.git" ] &&
+        git -C "$repo" rev-parse --verify HEAD >/dev/null 2>&1 &&
+        [ -f "$repo/pyproject.toml" ] &&
+        [ -d "$repo/plugins/blackbox" ]
+}
+
+move_broken_blackbox_repo_aside() {
+    local repo="$1"
+    local backup="${repo}.broken-$(date +%Y%m%d-%H%M%S)-$$"
+    warn "Existing install at $repo is incomplete or not an Agent Blackbox checkout."
+    mv -- "$repo" "$backup"
+    step "Preserved it at $backup"
+}
+
 resolve_repo() {
     local script_src="${BASH_SOURCE[0]:-}"
     if [ -n "$script_src" ] && [ -f "$script_src" ]; then
@@ -746,14 +763,30 @@ resolve_repo() {
         exit 1
     fi
     REPO_DIR="$BLACKBOX_INSTALL_ROOT"
-    if [ -d "$REPO_DIR/.git" ]; then
+    if [ -e "$REPO_DIR" ] && ! blackbox_repo_is_valid "$REPO_DIR"; then
+        move_broken_blackbox_repo_aside "$REPO_DIR"
+    fi
+    if blackbox_repo_is_valid "$REPO_DIR"; then
         step "Updating existing clone at $REPO_DIR"
-        git -C "$REPO_DIR" fetch --depth 1 origin "$REPO_BRANCH" >/dev/null 2>&1 || true
-        git -C "$REPO_DIR" checkout "$REPO_BRANCH" >/dev/null 2>&1 || true
-        git -C "$REPO_DIR" pull --ff-only >/dev/null 2>&1 || true
+        if ! git -C "$REPO_DIR" fetch --depth 1 origin "$REPO_BRANCH"; then
+            err "Could not fetch $REPO_BRANCH from $REPO_URL."
+            return 1
+        fi
+        if ! git -C "$REPO_DIR" checkout "$REPO_BRANCH"; then
+            err "Could not check out $REPO_BRANCH in $REPO_DIR. Resolve local changes and re-run."
+            return 1
+        fi
+        if ! git -C "$REPO_DIR" pull --ff-only origin "$REPO_BRANCH"; then
+            err "Could not fast-forward $REPO_DIR to origin/$REPO_BRANCH."
+            return 1
+        fi
     else
         step "Cloning $REPO_URL → $REPO_DIR"
         git clone --depth 1 --branch "$REPO_BRANCH" "$REPO_URL" "$REPO_DIR"
+    fi
+    if ! blackbox_repo_is_valid "$REPO_DIR"; then
+        err "$REPO_DIR is not a complete Agent Blackbox Python project."
+        return 1
     fi
     ok "Repo ready at $REPO_DIR"
 }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "majericmatic@gmail.com": "matic031",  # Agent Blackbox installer + VM-only release scope
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -139,7 +139,7 @@ def test_missing_community_does_not_restart_dkg_sync(monkeypatch):
     assert len(rs.dependency) == 1
 
 
-def test_partial_tier_error_preserves_public_rules(monkeypatch):
+def test_vm_error_preserves_public_rules_without_loading_swm(monkeypatch):
     monkeypatch.setattr(ruleset_mod, "_write_cache", lambda rs: None)
     prior = Ruleset(dependency={"npm:evil@1.0": {"identifier": "dep:npm:evil@1.0", "source": "public",
         "severity": "critical", "name": "m", "ecosystem": "npm", "packageName": "evil", "packageVersion": "1.0"}})
@@ -153,7 +153,7 @@ def test_partial_tier_error_preserves_public_rules(monkeypatch):
 
     rs = ruleset_mod.refresh(config_mod.BlackboxConfig(), _Partial())
     assert "npm:evil@1.0" in rs.dependency        # verified rule is preserved
-    assert len(rs.injection) == 1                  # fresh community tier still loaded
+    assert len(rs.injection) == 0                  # community SWM is never queried
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_blackbox_conversation_context.py
+++ b/tests/plugins/test_blackbox_conversation_context.py
@@ -199,8 +199,4 @@ def test_context_never_reaches_outbound_sighting(monkeypatch):
     }}
     hooks._report_and_audit(cfg, "pre_tool_call", [finding], detail)
 
-    assert shared, "sighting should have been shared for a heuristic finding"
-    blob = json.dumps(shared)
-    assert "CANARY_PROMPT" not in blob
-    assert "CANARY_INPUT" not in blob
-    assert "context" not in blob
+    assert shared == [], "threat sharing stays off until community SWM ships"

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -213,7 +213,9 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
         ("restart", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("status", constants.DEFAULT_CONTEXT_GRAPH_ID),
     ]
-    assert "2 public VM, 5 community SWM" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "2 public VM (curated)" in out
+    assert "Community graph (SWM): coming soon" in out
 
 
 def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, capsys):
@@ -545,6 +547,7 @@ def test_blackbox_request_join_does_not_treat_delivery_as_approval():
     assert "delivered to 1 curator host" in message
 
 
+@pytest.mark.skip(reason="private graph membership is not a Blackbox feature")
 def test_blackbox_sync_private_waits_for_approval_then_subscribes(monkeypatch):
     join_calls = []
     refresh_calls = []
@@ -616,6 +619,7 @@ def test_blackbox_sync_private_waits_for_approval_then_subscribes(monkeypatch):
     assert len(subscribe_calls) == 3
 
 
+@pytest.mark.skip(reason="private graph membership is not a Blackbox feature")
 def test_blackbox_sync_restarts_stale_empty_catchup_after_approval(monkeypatch, capsys):
     events = []
 
@@ -677,6 +681,7 @@ def test_blackbox_sync_restarts_stale_empty_catchup_after_approval(monkeypatch, 
     assert "Restarted DKG catch-up after approval" in capsys.readouterr().out
 
 
+@pytest.mark.skip(reason="legacy private graph sync is intentionally unsupported")
 def test_blackbox_sync_waits_for_fresh_dkg_catchup_without_restarting(monkeypatch):
     events = []
     statuses = iter([
@@ -740,6 +745,7 @@ def test_blackbox_sync_waits_for_fresh_dkg_catchup_without_restarting(monkeypatc
     assert ("restart", PRIVATE_CONTEXT_GRAPH_ID) not in events
 
 
+@pytest.mark.skip(reason="private graph membership is not a Blackbox feature")
 def test_blackbox_sync_reports_pending_approval_when_catchup_is_denied(monkeypatch, capsys):
     class FakeClient:
         def __init__(self, url, **_kwargs):

--- a/tests/plugins/test_blackbox_settings.py
+++ b/tests/plugins/test_blackbox_settings.py
@@ -21,6 +21,8 @@ config writes and audit logs never touch the real home.
 import os
 from pathlib import Path
 
+import pytest
+
 from _blackbox_loader import load_blackbox
 
 
@@ -441,6 +443,7 @@ def test_report_and_audit_never_shares_custom_finding(monkeypatch):
     assert private["called"] is False
 
 
+@pytest.mark.skip(reason="outbound threat sharing is disabled until community SWM ships")
 def test_report_and_audit_shares_non_custom_finding(monkeypatch):
     # Contrast: a community finding DOES reach share_knowledge_asset, proving
     # the custom-skip above is the discriminator (not a broken client).

--- a/tests/plugins/test_blackbox_vm_only.py
+++ b/tests/plugins/test_blackbox_vm_only.py
@@ -1,0 +1,125 @@
+"""Release contract: curated public VM only; community SWM is coming soon."""
+
+from argparse import Namespace
+
+from fastapi.testclient import TestClient
+
+from plugins.blackbox import cli, config, constants, detection, hooks, ruleset
+from plugins.blackbox.dashboard import server
+
+
+def test_refresh_queries_only_verifiable_memory(monkeypatch, tmp_path):
+    views = []
+
+    class Client:
+        def query(self, _query, _cg, **kwargs):
+            views.append(kwargs["view"])
+            return []
+
+    monkeypatch.setattr(constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset, "_memory_cache", None)
+    ruleset.refresh(config.BlackboxConfig(), Client())
+
+    assert views
+    assert set(views) == {constants.VIEW_VERIFIABLE_MEMORY}
+
+
+def test_cached_community_rules_are_discarded():
+    cached = {
+        "injection": [
+            {"identifier": "public", "source": "public", "pattern_src": "safe"},
+            {"identifier": "community", "source": "community", "pattern_src": "unsafe"},
+        ],
+        "graph_threats": [
+            {"identifier": "public", "source": "public"},
+            {"identifier": "community", "source": "community"},
+        ],
+    }
+
+    restored = ruleset._deserialize(cached)
+
+    assert [r["identifier"] for r in restored.injection] == ["public"]
+    assert [r["identifier"] for r in restored.graph_threats] == ["public"]
+
+
+def test_config_cannot_enable_threat_sharing(monkeypatch):
+    monkeypatch.setenv("BLACKBOX_REPORT", "true")
+    assert config.load_blackbox_config().report is False
+
+
+def test_report_command_submits_nothing(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "DkgClient", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("report must not create a DKG client")
+    ))
+
+    assert cli._cmd_report(Namespace()) == 2
+    assert "coming soon" in capsys.readouterr().out.lower()
+
+
+def test_detection_audit_never_shares(monkeypatch):
+    shared = []
+
+    class Client:
+        def share_knowledge_asset(self, *args):
+            shared.append(args)
+
+    monkeypatch.setattr(hooks.audit, "recently_reported", lambda _identifier: False)
+    monkeypatch.setattr(hooks.audit, "mark_reported", lambda _identifier: None)
+    monkeypatch.setattr(hooks.audit, "write_private_audit_ka", lambda *args: None)
+    monkeypatch.setattr(hooks, "DkgClient", lambda *args, **kwargs: Client())
+    hooks._report_and_audit(
+        config.BlackboxConfig(report=True),
+        "pre_tool_call",
+        [detection.Finding(
+            identifier="candidate", category="escalation", severity="critical",
+            title="candidate", confirmed=False, source="community",
+        )],
+        {},
+    )
+
+    assert shared == []
+
+
+def test_dashboard_sync_never_requests_private_join(monkeypatch):
+    events = []
+
+    class Cfg:
+        dkg_url = "http://127.0.0.1:9320"
+        dkg_home = "/tmp/blackbox"
+        context_graph_id = "legacy/private"
+
+    class Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        def subscribe_context_graph(self, cg_id):
+            events.append(("subscribe", cg_id))
+
+        def request_join(self, *_args):
+            raise AssertionError("private join must never be requested")
+
+    class Rules:
+        @staticmethod
+        def refresh(_cfg, _client):
+            return ruleset.Ruleset()
+
+    monkeypatch.setattr(server.sync_state, "read", lambda: {})
+    result = server._sync_ruleset_once(lambda: Cfg(), Client, Rules)
+
+    assert result == {"total": 0, "public": 0, "community": 0}
+    assert events == [("subscribe", "legacy/private")]
+
+
+def test_dashboard_community_surfaces_are_static_coming_soon(monkeypatch):
+    app = server.create_app()
+    with TestClient(app) as client:
+        graph = client.get("/api/graph?tier=community").json()
+        reports = client.get("/api/reports").json()
+        threat = client.get("/api/threat?tier=community&identifier=x").json()
+
+    assert graph == {
+        "tier": "community", "threats": [], "total": 0, "offset": 0,
+        "limit": 1000, "partial": False, "coming_soon": True,
+    }
+    assert reports == {"reports": [], "coming_soon": True, "sharing_enabled": False}
+    assert threat["coming_soon"] is True

--- a/tests/test_blackbox_dashboard_chat.py
+++ b/tests/test_blackbox_dashboard_chat.py
@@ -2,6 +2,7 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
 
 from plugins.blackbox import attach
@@ -177,6 +178,7 @@ def test_dashboard_lists_one_thousand_vm_threats_not_one_collection(monkeypatch)
     assert len({row["identifier"] for row in result["threats"]}) == 1000
 
 
+@pytest.mark.skip(reason="dashboard never joins private graphs")
 def test_ruleset_sync_once_uses_official_join_then_subscribe():
     class Cfg:
         dkg_url = "http://127.0.0.1:9320"
@@ -243,6 +245,7 @@ def test_ruleset_sync_once_uses_official_join_then_subscribe():
     ]
 
 
+@pytest.mark.skip(reason="old SWM count contract is no longer applicable")
 def test_ruleset_sync_once_does_not_compete_with_authoritative_sync(monkeypatch):
     class Cfg:
         dkg_url = "http://127.0.0.1:9320"
@@ -318,6 +321,7 @@ def test_dashboard_marks_subscribed_only_after_public_graph_arrives():
     assert server._connection_states[Cfg.context_graph_id]["state"] == "subscribed"
 
 
+@pytest.mark.skip(reason="covered by the public VM sync contract")
 def test_dashboard_restarts_stale_empty_completed_catchup():
     class Cfg:
         dkg_url = "http://127.0.0.1:9320"
@@ -367,6 +371,7 @@ def test_dashboard_restarts_stale_empty_completed_catchup():
     assert server._connection_states[Cfg.context_graph_id]["state"] == "syncing"
 
 
+@pytest.mark.skip(reason="community SWM is not synced")
 def test_dashboard_restarts_completed_catchup_when_only_community_synced():
     class Cfg:
         dkg_url = "http://127.0.0.1:9320"
@@ -468,6 +473,7 @@ def test_dashboard_clears_stale_pending_approval_once_catchup_is_running():
     assert server._connection_states[Cfg.context_graph_id]["state"] == "syncing"
 
 
+@pytest.mark.skip(reason="dashboard never repairs sync through a private join")
 def test_dashboard_failed_catchup_with_stale_public_rows_refreshes_join_before_restart():
     class Cfg:
         dkg_url = "http://127.0.0.1:9320"

--- a/tests/test_blackbox_install_llm_setup.py
+++ b/tests/test_blackbox_install_llm_setup.py
@@ -190,7 +190,11 @@ def test_windows_installer_creates_global_blackbox_launcher() -> None:
     assert text.index("Install-BlackboxCommand") < text.rindex("Install-Dkg")
 
 
-def _select_unix_install_root(home: Path, explicit: Path | None = None) -> Path:
+def _select_unix_install_root(
+    home: Path,
+    explicit: Path | None = None,
+    invocation_dir: Path | None = None,
+) -> Path:
     """Evaluate only the install-root preamble with an isolated fake home."""
     text = INSTALL_SH.read_text(encoding="utf-8")
     preamble = text.split('DKG_NETWORK="${BLACKBOX_DKG_NETWORK', 1)[0]
@@ -203,6 +207,7 @@ def _select_unix_install_root(home: Path, explicit: Path | None = None) -> Path:
         capture_output=True,
         text=True,
         env=env,
+        cwd=invocation_dir or home,
     )
     return Path(result.stdout)
 
@@ -319,7 +324,7 @@ def test_unix_installer_uses_isolated_blackbox_dkg_node() -> None:
     assert 'BLACKBOX_DKG_PORT="${BLACKBOX_DKG_PORT:-9320}"' in text
     assert 'BLACKBOX_DKG_STORE_PORT="${BLACKBOX_DKG_STORE_PORT:-9999}"' in text
     assert 'BLACKBOX_DKG_STORE_URL="${BLACKBOX_DKG_STORE_URL:-}"' in text
-    assert 'BLACKBOX_INSTALL_ROOT="$HOME/agent-blackbox"' in text
+    assert 'BLACKBOX_INSTALL_ROOT="$PWD/agent-blackbox"' in text
     assert 'BLACKBOX_DKG_HOME="$BLACKBOX_INSTALL_ROOT/.dkg"' in text
     assert 'BLACKBOX_DKG_CLI_DIR="$BLACKBOX_INSTALL_ROOT/dkg"' in text
     assert 'BLACKBOX_DKG_BIN="$BLACKBOX_DKG_CLI_DIR/node_modules/.bin/dkg"' in text
@@ -496,9 +501,10 @@ def test_unix_installer_uses_agent_blackbox_checkout(
 
     assert _select_unix_install_root(home) == home / "agent-blackbox"
 
-    repo_checkout = home / "agent-blackbox"
-    (repo_checkout / ".git").mkdir(parents=True)
-    assert _select_unix_install_root(home) == repo_checkout
+    repo_checkout = tmp_path / "existing-checkout"
+    (repo_checkout / "plugins" / "blackbox").mkdir(parents=True)
+    (repo_checkout / "pyproject.toml").write_text("[project]\nname='blackbox'\n")
+    assert _select_unix_install_root(home, invocation_dir=repo_checkout) == repo_checkout
 
     explicit = tmp_path / "custom-blackbox"
     assert _select_unix_install_root(home, explicit) == explicit
@@ -507,8 +513,8 @@ def test_unix_installer_uses_agent_blackbox_checkout(
 def test_windows_installer_uses_agent_blackbox_checkout() -> None:
     text = INSTALL_PS1.read_text(encoding="utf-8")
 
-    assert 'Test-Path "$env:USERPROFILE\\agent-blackbox\\.git"' in text
-    assert '$DefaultRepoDir = "$env:USERPROFILE\\agent-blackbox"' in text
+    assert 'Join-Path ([string](Get-Location)) "agent-blackbox"' in text
+    assert '$env:USERPROFILE\\agent-blackbox' not in text
 
 
 # The four mainnet-base core relays written to config.relayPeers.

--- a/tests/test_blackbox_install_repo_resolution.py
+++ b/tests/test_blackbox_install_repo_resolution.py
@@ -1,0 +1,144 @@
+"""Regression coverage for Agent Blackbox installer checkout resolution."""
+
+from __future__ import annotations
+
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "blackbox-install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "blackbox-install.ps1"
+
+
+def _shell_function(text: str, name: str) -> str:
+    match = re.search(rf"{name}\(\) \{{.*?\n\}}", text, re.DOTALL)
+    assert match is not None, f"{name}() not found"
+    return match.group(0)
+
+
+def test_shell_installer_defaults_to_invocation_directory() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert 'BLACKBOX_INSTALL_ROOT="$PWD/agent-blackbox"' in text
+    assert 'BLACKBOX_INSTALL_ROOT="$HOME/agent-blackbox"' not in text
+
+
+def test_shell_installer_rejects_incomplete_existing_checkout() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    validity = re.search(
+        r"blackbox_repo_is_valid\(\) \{.*?\n\}", text, re.DOTALL
+    )
+
+    assert validity is not None
+    block = validity.group(0)
+    assert "rev-parse --verify HEAD" in block
+    assert 'pyproject.toml' in block
+    assert 'plugins/blackbox' in block
+    assert "move_broken_blackbox_repo_aside" in text
+    assert '|| true' not in re.search(
+        r"resolve_repo\(\) \{.*?\n\}", text, re.DOTALL
+    ).group(0)
+
+
+def test_powershell_installer_matches_checkout_contract() -> None:
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert 'Join-Path ([string](Get-Location)) "agent-blackbox"' in text
+    assert '$env:USERPROFILE\\agent-blackbox' not in text
+    assert "function Test-BlackboxRepoCheckout" in text
+    assert "rev-parse --verify HEAD" in text
+    assert 'Test-Path "$Path\\pyproject.toml"' in text
+    assert 'Test-Path "$Path\\plugins\\blackbox"' in text
+    assert "Move-BrokenBlackboxRepoAside" in text
+    assert "Move-Item -LiteralPath $Path" in text
+
+
+@pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="requires git and bash",
+)
+def test_shell_installer_replaces_incomplete_checkout_with_real_clone(
+    tmp_path: Path,
+) -> None:
+    """Exercise the reported state: Git exists, project markers do not."""
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=source, check=True)
+    (source / "pyproject.toml").write_text("[project]\nname='agent-blackbox'\n")
+    (source / "plugins" / "blackbox").mkdir(parents=True)
+    (source / "plugins" / "blackbox" / "plugin.yaml").write_text("name: blackbox\n")
+    subprocess.run(["git", "add", "."], cwd=source, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+
+    install_dir = tmp_path / "agent-blackbox"
+    install_dir.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=install_dir, check=True)
+    (install_dir / "partial.txt").write_text("interrupted checkout\n")
+    subprocess.run(["git", "add", "."], cwd=install_dir, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "partial",
+        ],
+        cwd=install_dir,
+        check=True,
+        capture_output=True,
+    )
+
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _shell_function(text, name)
+        for name in (
+            "blackbox_repo_is_valid",
+            "move_broken_blackbox_repo_aside",
+            "resolve_repo",
+        )
+    )
+    script = f"""
+set -euo pipefail
+step() {{ :; }}
+ok() {{ :; }}
+warn() {{ :; }}
+err() {{ printf '%s\\n' "$*" >&2; }}
+BLACKBOX_INSTALL_ROOT={shlex.quote(str(install_dir))}
+REPO_URL={shlex.quote(str(source))}
+REPO_BRANCH=main
+{functions}
+resolve_repo
+"""
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (install_dir / "pyproject.toml").is_file()
+    assert (install_dir / "plugins" / "blackbox").is_dir()
+    backups = list(tmp_path.glob("agent-blackbox.broken-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "partial.txt").read_text() == "interrupted checkout\n"


### PR DESCRIPTION
## What changed

- default curl/pipe installs to `./agent-blackbox` under the invocation directory
- validate an existing checkout has a commit, `pyproject.toml`, and the Blackbox plugin before reuse
- preserve incomplete checkouts as `.broken-*` and clone cleanly
- stop swallowing fetch, checkout, and pull failures; mirror recovery in PowerShell
- sync and match threats only from the curated public Verifiable Memory graph
- strip legacy community entries from existing ruleset caches
- keep community SWM visible as **Coming soon** while disabling its reads, submissions, and threat sharing
- prevent Blackbox from requesting private-graph membership; the release graph is public

## Root cause

The installer treated any directory containing `.git` as ready, ignored failures from update commands, and then reused a partial virtual environment. An interrupted checkout could therefore reach editable installation without `pyproject.toml` or `setup.py`.

The product runtime also still contained active SWM query/report and legacy private-join paths even though the current release is intended to use only the curated public VM graph.

## Validation

- 49 installer-focused regression tests passed
- real Git recovery test reproduces and repairs the incomplete-checkout state
- 2,124 Blackbox/plugin tests passed in the broad local run after implementation; six obsolete SWM assertions were then updated
- 111 final focused tests passed (10 explicitly retired private/SWM behavior tests skipped)
- new VM-only contracts cover DKG view selection, stale-cache filtering, forced-off sharing, no-op report command, no private join, and static coming-soon dashboard APIs
- `bash -n scripts/blackbox-install.sh`
- Ruff and `git diff --check` passed
- editable Hermes package resolution succeeded
