### PR TITLE
feat(blackbox): add exclusive regular-first DKG sync coordinator

### DIFF
--- a/plugins/blackbox/README.md
+++ b/plugins/blackbox/README.md
@@ -83,6 +83,22 @@ Blackbox currently uses one shared graph:
 Raw prompts, commands, file contents, secrets, and your local audit trail are
 not published. Findings and reports stay local.
 
+### Graph synchronization
+
+Blackbox keeps a normal DKG context-graph subscription as the primary path.
+That subscription receives live graph updates and lets the DKG node reconcile
+verified content against blockchain state. If its catch-up job reaches a
+terminal failure, or completes without making any public threats queryable,
+Blackbox may recover from the configured publisher peer as a fallback.
+
+The two paths are controlled by one persisted state machine and one
+cross-process ownership lock. Publisher fallback cannot start while the normal
+DKG job is queued, running, or of unknown status. Before fallback, Blackbox
+temporarily pauses the live subscription, verifies that any race-winning job
+has drained, and restores the subscription after fallback stops. A timed-out
+publisher request also requires a managed DKG restart before another sync path
+can start.
+
 ## Configuration
 
 Settings are under `plugins.entries.blackbox` in `config.yaml`. The easiest way
@@ -98,7 +114,7 @@ to change them is through the dashboard settings page.
 | `detection.<category>.min_severity` | `info` | Minimum visible severity for a category |
 | `protected_paths` | `[]` | Local file globs that always block and are never shared |
 | `context_graph_id` | `0x37b1Fdfd…/agent-blackbox-vm` | Public verified threat graph |
-| `graph_peer_id` | bundled publisher peer | Authoritative threat-data sync source |
+| `graph_peer_id` | bundled publisher peer | Curator-pinned recovery source when regular DKG catch-up cannot complete |
 
 Categories are `injection`, `escalation`, `dependency`, `fileaccess`, and
 `skill`.
@@ -142,9 +158,10 @@ blackbox status
 blackbox sync --wait
 ```
 
-A first sync can continue in the background for several minutes. If it does not
-finish, rerun the command below and include the displayed peer ID and DKG log
-when reporting the problem:
+A first regular DKG sync can continue in the background for several minutes.
+Blackbox will not start curator recovery while that job is still active. If it
+does not finish, rerun the command below and include the displayed coordinator
+state, peer ID, and DKG log when reporting the problem:
 
 ```bash
 blackbox sync --wait --timeout 180

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -21,7 +21,17 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
-from . import attach, audit, constants, llm, quads, ruleset, settings, sync_state
+from . import (
+    attach,
+    audit,
+    constants,
+    llm,
+    quads,
+    ruleset,
+    settings,
+    sync_coordinator,
+    sync_state,
+)
 from .config import BlackboxConfig, load_blackbox_config
 from .dkg_client import DkgClient, DkgError
 from .dkg_progress import capture_durable_progress_cursor, read_durable_progress
@@ -29,8 +39,11 @@ from .dkg_progress import capture_durable_progress_cursor, read_durable_progress
 logger = logging.getLogger(__name__)
 
 _DKG_STEADY_SYNC_SETTINGS = {
-    "DKG_SYNC_ON_CONNECT_ENABLED": "1",
-    "DKG_SYNC_RECONCILER_ENABLED": "1",
+    "DKG_SYNC_ON_CONNECT_ENABLED": "0",
+    "DKG_SYNC_RECONCILER_ENABLED": "0",
+    # A persistent subscription's chain/VM reconciliation may invoke durable
+    # recovery. Keep that capability available in steady state; exclusivity is
+    # enforced by the coordinator and DKG's single-flight queue instead.
     "DKG_DURABLE_SYNC_ENABLED": "1",
     "DKG_SYNC_GLOBAL_MAX_INFLIGHT": "1",
     "DKG_SYNC_GLOBAL_QUEUE_LIMIT": "0",
@@ -462,8 +475,8 @@ def _cmd_sync(args: argparse.Namespace) -> int:
     """Run a ruleset sync, translating an interactive cancellation cleanly."""
     try:
         cfg = load_blackbox_config()
-        if _uses_managed_dkg(cfg, args):
-            return _cmd_sync_with_managed_dkg(cfg, args)
+        if _uses_managed_sync_window(cfg, args):
+            return _cmd_sync_in_managed_window(cfg, args)
         if getattr(args, "wait", False):
             with _managed_sync_lock() as acquired:
                 if not acquired:
@@ -479,16 +492,20 @@ def _cmd_sync(args: argparse.Namespace) -> int:
             except (TypeError, ValueError):
                 owns_transfer = False
             if current_transfer.get("status") == "running" and owns_transfer:
+                sync_mode = str(current_transfer.get("sync_mode") or "none")
                 sync_state.write(
                     "cancelled",
                     context_graph_id=current_transfer.get("context_graph_id"),
                     graph_peer_id=current_transfer.get("graph_peer_id"),
+                    coordinator_state=current_transfer.get("coordinator_state"),
+                    sync_mode=sync_mode,
                     phase=str(current_transfer.get("phase") or "cancelled"),
                     public_entries=int(current_transfer.get("public_entries") or 0),
                     expected_public_entries=int(
                         current_transfer.get("expected_public_entries") or 0
                     ),
                     community_entries=int(current_transfer.get("community_entries") or 0),
+                    requires_dkg_restart=sync_mode == "fallback",
                     error="sync cancelled by user",
                 )
         except Exception as exc:  # cancellation must never print a traceback
@@ -497,11 +514,10 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         return 130
 
 
-def _uses_managed_dkg(cfg: BlackboxConfig, args: argparse.Namespace) -> bool:
-    """Return whether this is a blocking sync for Blackbox's managed DKG."""
+def _uses_managed_sync_window(cfg: BlackboxConfig, _args: argparse.Namespace) -> bool:
+    """Return whether this sync targets Blackbox's locally managed DKG."""
     return bool(
-        getattr(args, "wait", False)
-        and cfg.context_graph_id == constants.DEFAULT_CONTEXT_GRAPH_ID
+        cfg.context_graph_id == constants.DEFAULT_CONTEXT_GRAPH_ID
         and cfg.graph_peer_id
         and Path(cfg.dkg_bin).is_file()
         and Path(cfg.dkg_home).is_dir()
@@ -551,10 +567,11 @@ def _managed_sync_lock():
         handle.close()
 
 
-def _dkg_sync_environment(cfg: BlackboxConfig) -> Dict[str, str]:
+def _dkg_sync_environment(cfg: BlackboxConfig, *, durable: bool) -> Dict[str, str]:
     env = os.environ.copy()
     env.update(_DKG_STEADY_SYNC_SETTINGS)
     env["DKG_HOME"] = str(cfg.dkg_home)
+    env["DKG_DURABLE_SYNC_ENABLED"] = "1" if durable else "0"
     env.setdefault("DKG_CATCHUP_MAX_CONCURRENT_PEERS", "1")
     env.setdefault("DKG_STORE_QUEUE_WAIT_TIMEOUT_MS", "300000")
     env.setdefault("DKG_SYNC_TOTAL_TIMEOUT_MS", "1800000")
@@ -649,31 +666,30 @@ def _node_runtime_matches_dkg(executable: Path, cfg: BlackboxConfig) -> bool:
 
 
 def _set_persisted_dkg_steady_state(cfg: BlackboxConfig) -> bool:
-    """Persist bounded native reconciliation and report whether it changed."""
+    """Persist hybrid subscription settings and report whether they changed."""
     path = Path(cfg.dkg_home) / "config.json"
     data = json.loads(path.read_text(encoding="utf-8"))
-    original = json.dumps(data, sort_keys=True)
-    data.update(
-        {
-            "syncOnConnectEnabled": True,
-            "syncReconcilerEnabled": True,
-            "durableSyncEnabled": True,
-            "syncGlobalMaxInflight": 1,
-            "syncGlobalQueueLimit": 0,
-            "syncSharedMemoryOnConnect": False,
-        }
-    )
-    if original == json.dumps(data, sort_keys=True):
+    desired = {
+        "syncOnConnectEnabled": False,
+        "syncReconcilerEnabled": False,
+        "durableSyncEnabled": True,
+        "syncGlobalMaxInflight": 1,
+        "syncGlobalQueueLimit": 0,
+        "syncSharedMemoryOnConnect": False,
+    }
+    changed = any(data.get(key) != value for key, value in desired.items())
+    if not changed:
         return False
+    data.update(desired)
     tmp = path.with_suffix(f".tmp-{os.getpid()}")
     tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     os.replace(tmp, path)
     return True
 
 
-def _restart_managed_dkg(cfg: BlackboxConfig) -> None:
-    """Restart the managed node with bounded native reconciliation enabled."""
-    env = _dkg_sync_environment(cfg)
+def _restart_managed_dkg(cfg: BlackboxConfig, *, durable: bool) -> None:
+    """Restart the managed node in a controlled sync or steady-state mode."""
+    env = _dkg_sync_environment(cfg, durable=durable)
     command = str(cfg.dkg_bin)
     try:
         subprocess.run(
@@ -735,40 +751,61 @@ def _last_sync_counts(context_graph_id: str = "") -> tuple[int, int]:
     return public, community
 
 
-def _cmd_sync_with_managed_dkg(cfg: BlackboxConfig, args: argparse.Namespace) -> int:
-    """Run one foreground catch-up while DKG owns ongoing reconciliation."""
+def _cmd_sync_in_managed_window(cfg: BlackboxConfig, args: argparse.Namespace) -> int:
+    """Run one hybrid sync while holding the cross-process ownership slot."""
     with _managed_sync_lock() as acquired:
         if not acquired:
             print("Blackbox sync is already running; no second transfer was queued.")
             return 2 if getattr(args, "require_rules", False) else 0
 
+        previous = sync_state.read_for_graph(cfg.context_graph_id)
+        previous_fallback_uncertain = bool(
+            previous.get("requires_dkg_restart")
+            or (
+                previous.get("sync_mode") == "fallback"
+                and previous.get("status") in {"running", "failed"}
+            )
+        )
         known_public, known_community = _last_sync_counts(cfg.context_graph_id)
         sync_state.write(
             "running",
             context_graph_id=cfg.context_graph_id,
             graph_peer_id=cfg.graph_peer_id,
-            phase="preparing-managed-sync",
+            phase="preparing-hybrid-sync",
+            coordinator_state=sync_coordinator.PREPARING,
+            sync_mode="none",
             public_entries=known_public,
             community_entries=known_community,
         )
-        terminal_state: Dict[str, Any] = {}
-        result = 2
-        failure: Optional[BaseException] = None
         try:
-            # Upgrade installs that previously disabled the native reconciler.
-            # Do not restart an already-correct node: preserving the pinned
-            # curator connection lets DKG resume the same manifest after this
-            # foreground command reaches its own deadline.
-            if _set_persisted_dkg_steady_state(cfg):
-                _restart_managed_dkg(cfg)
+            settings_changed = _set_persisted_dkg_steady_state(cfg)
+            node_unreachable = False
+            if not settings_changed and not previous_fallback_uncertain:
+                try:
+                    DkgClient(url=cfg.dkg_url, dkg_home=cfg.dkg_home).status(timeout=2)
+                except DkgError:
+                    node_unreachable = True
+            if settings_changed or previous_fallback_uncertain or node_unreachable:
+                _restart_managed_dkg(cfg, durable=True)
+                previous_fallback_uncertain = False
             result = _cmd_sync_impl(args)
-            terminal_state = sync_state.read_for_graph(cfg.context_graph_id)
-        except BaseException as exc:
-            failure = exc
-            terminal_state = sync_state.read_for_graph(cfg.context_graph_id)
+        except Exception as exc:
+            current = sync_state.read_for_graph(cfg.context_graph_id)
+            failed_details = _terminal_sync_details(current)
+            failed_details.update(
+                context_graph_id=cfg.context_graph_id,
+                graph_peer_id=cfg.graph_peer_id,
+                coordinator_state=sync_coordinator.FAILED,
+                sync_mode="none",
+                phase=str(current.get("phase") or "failed"),
+                error=str(exc),
+            )
+            if previous_fallback_uncertain:
+                failed_details["requires_dkg_restart"] = True
+            sync_state.write("failed", **failed_details)
+            raise
 
-        if failure is not None:
-            raise failure
+        terminal_state = sync_state.read_for_graph(cfg.context_graph_id)
         status = str(terminal_state.get("status") or "")
         if status == "running" or not status:
             status = "done" if result == 0 else "failed"
@@ -790,9 +827,6 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     )
     admitted = not private_graph
     pending_approval = private_graph
-    # The pinned curator remains the preferred foreground source, but the DKG
-    # subscription is still persisted below. That durable subscription is what
-    # lets DKG continue reconciling after this command exits or the node restarts.
     subscribed = False
     catchup_restarted = False
     baseline_catchup_known = False
@@ -812,14 +846,15 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     deadline = time.monotonic() + max(1, int(getattr(args, "timeout", 180) or 180))
     track_sync = bool(getattr(args, "wait", False))
 
-    if (
-        release_graph
-        and getattr(args, "wait", False)
-        and getattr(args, "require_rules", False)
-        and not authoritative_available
-    ):
-        print("  Required curator-pinned VM recovery is unavailable in this DKG build.")
-        return 2
+    if release_graph:
+        return _sync_release_graph(
+            args,
+            cfg,
+            client,
+            deadline=deadline,
+            track_sync=track_sync,
+            authoritative_available=authoritative_available,
+        )
 
     if track_sync:
         known_public, known_community = _last_sync_counts(cfg.context_graph_id)
@@ -915,58 +950,6 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             last_join_attempt = time.monotonic()
             if status and attempt % 10 == 0:
                 print(status)
-
-        # The release graph has one known complete source peer. A fresh node
-        # asks it first instead of downloading unrelated durable graphs from
-        # every generic peer and only falling back minutes later.
-        # If the direct path fails, the ordinary subscription/catch-up path
-        # below remains available for compatibility and recovery.
-        if (
-            release_graph
-            and getattr(args, "wait", False)
-            and authoritative_available
-            and not authoritative_attempted
-        ):
-            authoritative_attempted = True
-            authoritative_recovered = _catchup_authoritative_vm(
-                client,
-                cfg.context_graph_id,
-                cfg.graph_peer_id,
-                deadline,
-                on_progress=_record_verified_pass,
-            )
-            if not authoritative_recovered and getattr(args, "require_rules", False):
-                print(
-                    "  Foreground curator recovery did not complete; "
-                    "persisting the DKG subscription for native reconciliation."
-                )
-            # Successful DKG passes already refreshed the verified cache via
-            # ``_record_verified_pass``. If the pinned source failed before a
-            # pass settled, do not launch a competing full-store query merely
-            # to decide whether to persist the background subscription.
-            if authoritative_recovered:
-                try:
-                    rs = ruleset.refresh(cfg, client, force_query=True)
-                except ruleset.RulesetRefreshUnavailable:
-                    rs = ruleset.peek(cfg)
-                else:
-                    authoritative_cache_refreshed = True
-            else:
-                rs = ruleset.peek(cfg)
-            counts = rs.counts()
-            public_count = max(public_count, _ruleset_graph_count(rs, "public"))
-            community_count = _ruleset_graph_count(rs, "community")
-            authoritative_target = max(authoritative_target, public_count)
-            if authoritative_recovered:
-                # The pinned pass established a complete foreground snapshot.
-                # Still flow through the subscription call below so that DKG
-                # owns future updates and restart-safe reconciliation.
-                fresh_catchup_seen = True
-                authoritative_complete = (
-                    authoritative_cache_refreshed
-                    and authoritative_target > 0
-                    and public_count >= authoritative_target
-                )
 
         may_probe_private = private_graph and not getattr(args, "wait", False)
         if not subscribed and (admitted or not private_graph or may_probe_private):
@@ -1110,7 +1093,6 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         if (
             managed_graph
             and subscribed
-            and not release_graph
             and not catchup_restarted
             and (
                 catchup_includes_swm
@@ -1166,7 +1148,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         # not hold the graph.  Once the release graph is subscribed, pin the
         # authoritative source immediately; the recovery helper already
         # waits through DKG backpressure and verifies completion atomically.
-        authoritative_recovery_ready = base_sync_complete or release_graph
+        authoritative_recovery_ready = base_sync_complete
         if (
             authoritative_recovery_ready
             and managed_graph
@@ -1362,6 +1344,347 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     return 0
 
 
+def _subscribe_release_graph(client: DkgClient, context_graph_id: str) -> Dict[str, Any]:
+    """Subscribe VM-only while tolerating older client wrappers."""
+    try:
+        return client.subscribe_context_graph(
+            context_graph_id,
+            include_shared_memory=False,
+        )
+    except TypeError:
+        return client.subscribe_context_graph(context_graph_id)
+
+
+def _restore_release_subscription(client: DkgClient, context_graph_id: str) -> str:
+    """Restore the primary path after a fully stopped fallback; return an error."""
+    try:
+        _subscribe_release_graph(client, context_graph_id)
+    except (DkgError, AttributeError) as exc:
+        return str(exc)
+    return ""
+
+
+def _sync_release_graph(
+    args: argparse.Namespace,
+    cfg: BlackboxConfig,
+    client: DkgClient,
+    *,
+    deadline: float,
+    track_sync: bool,
+    authoritative_available: bool,
+) -> int:
+    """Synchronize the release graph through the exclusive hybrid coordinator."""
+    known_public, known_community = _last_sync_counts(cfg.context_graph_id)
+    coordinator = sync_coordinator.HybridSyncCoordinator(
+        sync_state.write,
+        cfg.context_graph_id,
+        cfg.graph_peer_id,
+    )
+    if track_sync:
+        coordinator.publish_initial(
+            public_entries=known_public,
+            community_entries=known_community,
+        )
+    coordinator.start_regular(
+        public_entries=known_public,
+        community_entries=known_community,
+    )
+
+    try:
+        subscription = _subscribe_release_graph(client, cfg.context_graph_id)
+    except DkgError as exc:
+        error = (
+            "regular DKG subscription failed before its job state could be "
+            f"verified: {exc}"
+        )
+        coordinator.fail(error, phase="regular-subscription-failed")
+        print(f"warning: {error}")
+        print("  Curator fallback was not started because regular-job state is unknown.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    print(f"Subscribed to {cfg.context_graph_id}; regular DKG catch-up is primary.")
+    regular_status = coordinator.observe_regular(subscription)
+    regular_job_id = _catchup_job_id(subscription)
+    last_catchup = subscription
+    wait = bool(getattr(args, "wait", False))
+
+    while wait and regular_status not in sync_coordinator.REGULAR_TERMINAL_STATUSES:
+        now = time.monotonic()
+        if now >= deadline:
+            state = regular_status or "unknown"
+            error = (
+                f"regular DKG catch-up remained {state}; curator fallback was "
+                "suppressed to prevent concurrent recovery"
+            )
+            coordinator.fail(error, phase="regular-catchup-blocked")
+            print(f"  {error}.")
+            return 2 if getattr(args, "require_rules", False) else 0
+        try:
+            last_catchup, _exact_job_status = _catchup_status(
+                client,
+                cfg.context_graph_id,
+                regular_job_id,
+            )
+            regular_status = coordinator.observe_regular(last_catchup)
+        except (DkgError, AttributeError) as exc:
+            logger.debug("blackbox: regular catch-up status unavailable: %s", exc)
+            regular_status = ""
+        if regular_status not in sync_coordinator.REGULAR_TERMINAL_STATUSES:
+            state = regular_status or "unknown"
+            print(f"Waiting for regular DKG catch-up ({state})...")
+            time.sleep(min(3.0, max(0.2, deadline - now)))
+
+    if regular_status in sync_coordinator.REGULAR_ACTIVE_STATUSES:
+        rs = ruleset.peek(cfg)
+    else:
+        try:
+            rs = ruleset.refresh(cfg, client, force_query=True)
+        except ruleset.RulesetRefreshUnavailable:
+            rs = ruleset.peek(cfg)
+    counts = rs.counts()
+    public_count = _ruleset_graph_count(rs, "public")
+    community_count = _ruleset_graph_count(rs, "community")
+
+    regular_succeeded = (
+        regular_status in sync_coordinator.REGULAR_SUCCESS_STATUSES
+        and public_count > 0
+    )
+    if regular_succeeded:
+        coordinator.start_reconciling(
+            public_entries=public_count,
+            expected_public_entries=public_count,
+            community_entries=community_count,
+        )
+        coordinator.complete(
+            public_entries=public_count,
+            expected_public_entries=public_count,
+            community_entries=community_count,
+        )
+        _print_release_sync_summary(cfg, counts, public_count)
+        return 0
+
+    if not wait:
+        error = (
+            "regular DKG catch-up is not terminal"
+            if regular_status not in sync_coordinator.REGULAR_TERMINAL_STATUSES
+            else "regular DKG catch-up did not make public threats queryable"
+        )
+        coordinator.fail(error, phase="regular-catchup-incomplete")
+        _print_release_sync_summary(cfg, counts, public_count)
+        if getattr(args, "require_rules", False):
+            print("  Required ruleset sync is incomplete.")
+            return 2
+        return 0
+
+    if regular_status not in sync_coordinator.REGULAR_TERMINAL_STATUSES:
+        error = "regular DKG catch-up state is unknown; curator fallback was suppressed"
+        coordinator.fail(error, phase="regular-catchup-blocked")
+        print(f"  {error}.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    if regular_status in sync_coordinator.REGULAR_SUCCESS_STATUSES:
+        reason = "regular DKG catch-up completed without queryable public threats"
+        coordinator.mark_regular_empty(
+            reason,
+            public_entries=public_count,
+            community_entries=community_count,
+        )
+    else:
+        detail = ""
+        if isinstance(last_catchup, dict):
+            result = last_catchup.get("result")
+            detail = str(
+                last_catchup.get("error")
+                or (result.get("error") if isinstance(result, dict) else "")
+                or ""
+            )
+        reason = f"regular DKG catch-up ended as {regular_status}"
+        if detail:
+            reason += f": {detail}"
+
+    if not authoritative_available:
+        error = f"{reason}; curator fallback is unavailable in this DKG build"
+        coordinator.fail(error, phase="fallback-unavailable")
+        print(f"  {error}.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    # First gate: a concurrent daemon action may have started a new regular job
+    # after the terminal result above. Fallback remains forbidden in that case.
+    try:
+        gate = client.catchup_status(cfg.context_graph_id)
+        gate_status = sync_coordinator.catchup_status(gate)
+    except (DkgError, AttributeError) as exc:
+        error = f"could not verify the regular catch-up drain gate: {exc}"
+        coordinator.fail(error, phase="fallback-drain-unknown")
+        print(f"  {error}; curator fallback was not started.")
+        return 2 if getattr(args, "require_rules", False) else 0
+    if gate_status not in sync_coordinator.REGULAR_TERMINAL_STATUSES:
+        state = gate_status or "unknown"
+        error = f"regular DKG catch-up drain gate is {state}"
+        coordinator.fail(error, phase="fallback-drain-blocked")
+        print(f"  {error}; curator fallback was not started.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    coordinator.queue_fallback(
+        reason,
+        public_entries=public_count,
+        community_entries=community_count,
+    )
+    pause = getattr(client, "unsubscribe_context_graph", None)
+    if not callable(pause):
+        error = "DKG cannot pause the regular subscription for exclusive fallback"
+        coordinator.fail(error, phase="fallback-pause-unavailable")
+        print(f"  {error}; curator fallback was not started.")
+        return 2 if getattr(args, "require_rules", False) else 0
+    try:
+        pause(cfg.context_graph_id)
+    except DkgError as exc:
+        error = f"could not pause the regular DKG subscription: {exc}"
+        coordinator.fail(error, phase="fallback-pause-failed")
+        print(f"  {error}; curator fallback was not started.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    # Second gate: unsubscribe removes gossip handlers and the subscribed-CG
+    # reconciliation scope. If a regular job won the race just before that
+    # pause, wait for that already-started job to drain before fallback.
+    while True:
+        try:
+            drained = client.catchup_status(cfg.context_graph_id)
+            drained_status = sync_coordinator.catchup_status(drained)
+        except (DkgError, AttributeError) as exc:
+            restore_error = _restore_release_subscription(client, cfg.context_graph_id)
+            error = f"could not verify the paused regular catch-up drain: {exc}"
+            if restore_error:
+                error += f"; subscription restore failed: {restore_error}"
+            coordinator.fail(error, phase="fallback-drain-unknown")
+            print(f"  {error}; curator fallback was not started.")
+            return 2 if getattr(args, "require_rules", False) else 0
+        if drained_status in sync_coordinator.REGULAR_TERMINAL_STATUSES:
+            break
+        now = time.monotonic()
+        if drained_status not in sync_coordinator.REGULAR_ACTIVE_STATUSES or now >= deadline:
+            restore_error = _restore_release_subscription(client, cfg.context_graph_id)
+            state = drained_status or "unknown"
+            error = f"paused regular DKG catch-up did not drain from {state}"
+            if restore_error:
+                error += f"; subscription restore failed: {restore_error}"
+            coordinator.fail(error, phase="fallback-drain-blocked")
+            print(f"  {error}; curator fallback was not started.")
+            return 2 if getattr(args, "require_rules", False) else 0
+        print(f"Waiting for paused regular DKG catch-up to drain ({drained_status})...")
+        time.sleep(min(3.0, max(0.2, deadline - now)))
+
+    coordinator.start_fallback(
+        public_entries=public_count,
+        community_entries=community_count,
+    )
+    authoritative_target = public_count
+
+    def _record_verified_pass(_inserted_triples: int) -> None:
+        nonlocal authoritative_target
+        count_threats = getattr(client, "threat_count", None)
+        if callable(count_threats):
+            authoritative_target = max(
+                authoritative_target,
+                int(count_threats(cfg.context_graph_id) or 0),
+            )
+        sync_state.write(
+            "running",
+            context_graph_id=cfg.context_graph_id,
+            graph_peer_id=cfg.graph_peer_id,
+            phase="recovering-verifiable-memory",
+            public_entries=authoritative_target,
+            community_entries=community_count,
+        )
+        if authoritative_target > 0:
+            print(f"  {authoritative_target:,} verified threats ready")
+
+    recovered = _catchup_authoritative_vm(
+        client,
+        cfg.context_graph_id,
+        cfg.graph_peer_id,
+        deadline,
+        on_progress=_record_verified_pass,
+    )
+    if not recovered:
+        current = sync_state.read()
+        error = str(current.get("error") or "curator fallback recovery did not complete")
+        requires_restart = bool(current.get("requires_dkg_restart"))
+        if not requires_restart:
+            restore_error = _restore_release_subscription(client, cfg.context_graph_id)
+            if restore_error:
+                error += f"; subscription restore failed: {restore_error}"
+        coordinator.fail(
+            error,
+            phase=str(current.get("phase") or "fallback-failed"),
+            public_entries=public_count,
+            community_entries=community_count,
+            requires_dkg_restart=requires_restart,
+        )
+        print("  Required curator fallback recovery did not complete.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    coordinator.start_reconciling(
+        public_entries=authoritative_target,
+        expected_public_entries=authoritative_target,
+        community_entries=community_count,
+    )
+    try:
+        rs = ruleset.refresh(cfg, client, force_query=True)
+    except ruleset.RulesetRefreshUnavailable:
+        rs = ruleset.peek(cfg)
+    counts = rs.counts()
+    public_count = _ruleset_graph_count(rs, "public")
+    community_count = _ruleset_graph_count(rs, "community")
+    authoritative_target = max(authoritative_target, public_count)
+    restore_error = _restore_release_subscription(client, cfg.context_graph_id)
+    if restore_error:
+        error = f"curator recovery completed but regular subscription restore failed: {restore_error}"
+        coordinator.fail(
+            error,
+            phase="regular-subscription-restore-failed",
+            public_entries=public_count,
+            expected_public_entries=authoritative_target,
+            community_entries=community_count,
+        )
+        print(f"  {error}.")
+        return 2 if getattr(args, "require_rules", False) else 0
+    if public_count <= 0:
+        error = "authoritative VM returned no public threat entries"
+        coordinator.fail(
+            error,
+            phase="empty-verifiable-memory",
+            public_entries=0,
+            expected_public_entries=authoritative_target,
+            community_entries=community_count,
+        )
+        print("  authoritative VM returned zero public threat entries.")
+        print("  No rules are available to protect this node.")
+        return 2 if getattr(args, "require_rules", False) else 0
+
+    coordinator.complete(
+        public_entries=public_count,
+        expected_public_entries=authoritative_target or public_count,
+        community_entries=community_count,
+    )
+    _print_release_sync_summary(cfg, counts, public_count)
+    return 0
+
+
+def _print_release_sync_summary(
+    cfg: BlackboxConfig,
+    counts: Dict[str, Any],
+    public_count: int,
+) -> None:
+    print(f"Ruleset synced from {cfg.context_graph_id}:")
+    print(
+        f"  {counts['injection']} injection, {counts['escalation']} escalation, "
+        f"{counts['dependency']} dependency"
+    )
+    print(f"  {public_count:,} public VM (curated)")
+    print("  Community graph (SWM): coming soon")
+
+
 def _ruleset_graph_count(rs: Any, source: str) -> int:
     for name in ("graph_count", "source_count"):
         counter = getattr(rs, name, None)
@@ -1448,7 +1771,7 @@ def _catchup_authoritative_vm(
                 int(max(1.0, remaining - 10) * 1_000),
             ),
         )
-        request_still_active = False
+        request_may_be_running = False
         try:
             # The DKG endpoint is synchronous and its final verification/store
             # phase can outlive a socket inactivity timeout. Run it behind a
@@ -1494,13 +1817,13 @@ def _catchup_authoritative_vm(
                     max(0.0, request_deadline - time.monotonic()),
                 )
                 if wait_for <= 0:
-                    request_still_active = worker.is_alive()
+                    request_may_be_running = worker.is_alive()
                     raise DkgError(
                         "verifiable VM sync watchdog reached its "
                         f"{request_timeout_seconds}s settlement deadline"
                         + (
                             " while the DKG request remains active"
-                            if request_still_active
+                            if request_may_be_running
                             else ""
                         )
                     )
@@ -1526,7 +1849,32 @@ def _catchup_authoritative_vm(
             result = outcome_value
         except DkgError as exc:
             error = str(exc)
-            retryable = not request_still_active and any(
+            lowered_error = error.lower()
+            request_may_be_running = request_may_be_running or (
+                "queue wait timeout" not in lowered_error
+                and any(
+                    marker in lowered_error
+                    for marker in ("transport error", "timed out", "timeout")
+                )
+            )
+            if request_may_be_running:
+                sync_state.write(
+                    "failed",
+                    context_graph_id=context_graph_id,
+                    graph_peer_id=graph_peer_id,
+                    phase="fallback-request-uncertain",
+                    requires_dkg_restart=True,
+                    error=(
+                        f"{error}; DKG must be restarted before another sync "
+                        "path may start"
+                    ),
+                )
+                logger.debug(
+                    "blackbox: curator fallback request may still be active: %s",
+                    exc,
+                )
+                return False
+            retryable = any(
                 marker in error.lower()
                 for marker in (
                     "backpressure",
@@ -1535,8 +1883,6 @@ def _catchup_authoritative_vm(
                     "durable_catchup_all_peers_failed",
                     "store scheduler",
                     "queue wait timeout",
-                    "timed out",
-                    "exceeded its",
                 )
             )
             if (
@@ -1614,6 +1960,7 @@ def _catchup_authoritative_vm(
             return False
         backpressure_retries = 0
         inserted = int(result.get("totalDurableInsertedTriples") or 0)
+        explicit_durable_complete = result.get("durableComplete")
         durable_progress = read_durable_progress(
             str(getattr(client, "dkg_home", "") or ""),
             context_graph_id,
@@ -1621,9 +1968,9 @@ def _catchup_authoritative_vm(
         )
         # Newer DKG releases report the request's completion contract directly.
         # Retain daemon-log parsing as a compatibility fallback for 10.0.9.
-        if result.get("durableComplete") is True:
+        if explicit_durable_complete is True:
             durable_progress["snapshot_complete"] = True
-        elif result.get("durableComplete") is False:
+        elif explicit_durable_complete is False:
             durable_progress["snapshot_complete"] = False
         sync_state.write(
             "running",
@@ -1640,7 +1987,12 @@ def _catchup_authoritative_vm(
         durable_progress = read_durable_progress(
             str(getattr(client, "dkg_home", "") or ""),
             context_graph_id,
+            after=progress_cursor,
         )
+        if explicit_durable_complete is True:
+            durable_progress["snapshot_complete"] = True
+        elif explicit_durable_complete is False:
+            durable_progress["snapshot_complete"] = False
         if inserted <= 0:
             expected = int(durable_progress.get("expected_triples") or 0)
             safe_current = int(durable_progress.get("safe_current_triples") or 0)

--- a/plugins/blackbox/dashboard/server.py
+++ b/plugins/blackbox/dashboard/server.py
@@ -236,10 +236,10 @@ def _network_sync_once(
 ) -> Dict[str, Any]:
     """Fetch and verify the latest VM snapshot, once per dashboard process.
 
-    The CLI owns the complete curator-pinned recovery protocol and publishes
-    progress through ``sync_state``. Running it in a subprocess keeps a long
-    network transfer isolated from the dashboard server while its status
-    remains visible to every dashboard poll.
+    The CLI owns the regular-first hybrid coordinator and publishes progress
+    through ``sync_state``. Running it in a subprocess keeps a long network
+    transfer isolated from the dashboard server while its status remains
+    visible to every dashboard poll.
     """
     if not _network_sync_lock.acquire(blocking=False):
         cfg = load_config()
@@ -402,6 +402,8 @@ def _sync_activity(
     connection_state = str(connection.get("state") or "").lower()
     transfer_status = str(transfer.get("status") or "").lower()
     phase = str(transfer.get("phase") or "").lower()
+    coordinator_state = str(transfer.get("coordinator_state") or "").lower()
+    sync_mode = str(transfer.get("sync_mode") or "none").lower()
     current = int(transfer.get("public_entries") or public or 0)
     expected = int(transfer.get("expected_public_entries") or 0)
     current_triples = int(transfer.get("current_triples") or 0)
@@ -417,10 +419,17 @@ def _sync_activity(
         "expected": None,
         "percent": None,
         "indeterminate": True,
+        "coordinator_state": coordinator_state or None,
+        "sync_mode": sync_mode,
     }
 
     if transfer_status == "running":
         labels = {
+            "preparing-hybrid-sync": "Preparing graph synchronization",
+            "regular-subscribing": "Subscribing to threat graph",
+            "network-catchup": "Regular DKG catch-up",
+            "regular-terminal": "Checking regular DKG result",
+            "fallback-pending": "Switching to curator recovery",
             "recovering-verifiable-memory": "Receiving publisher VM",
             "waiting-for-verifiable-memory": "Verifying publisher VM",
             "refreshing-verifiable-memory": "Refreshing verified threats",
@@ -482,6 +491,15 @@ def _sync_activity(
                 expected=expected,
                 percent=round((bounded / expected) * 100, 1),
                 indeterminate=False,
+            )
+        elif phase == "fallback-pending":
+            progress["detail"] = (
+                "The regular DKG job is terminal; curator recovery is waiting "
+                "behind the exclusive drain gate."
+            )
+        elif phase in {"regular-subscribing", "network-catchup", "regular-terminal"}:
+            progress["detail"] = (
+                "The local DKG subscription is fetching and verifying the threat graph."
             )
         else:
             progress["detail"] = "The DKG node is receiving and verifying an atomic snapshot."
@@ -1399,14 +1417,12 @@ def create_app(*, manage_blackbox: bool = False):
             except (TypeError, ValueError):
                 pass
         if authoritative_running:
-            # The curator-pinned durable transfer is intentionally separate
-            # from DKG's generic catch-up job. Keep the loader honest while a
-            # partial but usable VM snapshot is being expanded in the
-            # background.
+            # The coordinator may be in regular catch-up, the drain gate, or
+            # curator fallback. Keep the loader honest until that single owner
+            # publishes a terminal result.
             catchup_state = "running"
         elif authoritative_done and node_catchup_state.lower() not in {"queued", "running"}:
-            # The curator transfer records both tiers, including a legitimate
-            # zero-entry SWM.  Prefer that completed result over a stale generic
+            # Prefer the coordinator's completed result over a stale daemon
             # catch-up probe/connection hint.
             catchup_state = "done"
         public_state = (

--- a/plugins/blackbox/dkg_client.py
+++ b/plugins/blackbox/dkg_client.py
@@ -256,7 +256,6 @@ class DkgClient:
             cg_id,
             include_shared_memory=include_shared_memory,
         )
-
     def catchup_status(
         self,
         cg_id: str,

--- a/plugins/blackbox/sync_coordinator.py
+++ b/plugins/blackbox/sync_coordinator.py
@@ -1,0 +1,170 @@
+"""Exclusive state machine for Blackbox's hybrid DKG graph synchronization.
+
+The normal DKG context-graph subscription is always the primary path.  The
+curator-pinned recovery path is only legal after the normal job has reached a
+known terminal state.  Keeping that rule in a small state machine makes it
+hard for a future retry branch to accidentally start both paths at once.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict
+
+
+REGULAR_ACTIVE_STATUSES = frozenset({"queued", "running"})
+REGULAR_SUCCESS_STATUSES = frozenset({"done"})
+REGULAR_FAILURE_STATUSES = frozenset(
+    {"failed", "cancelled", "denied", "unreachable", "deferred"}
+)
+REGULAR_TERMINAL_STATUSES = REGULAR_SUCCESS_STATUSES | REGULAR_FAILURE_STATUSES
+
+PREPARING = "preparing"
+REGULAR_SUBSCRIBING = "regular-subscribing"
+REGULAR_ACTIVE = "regular-active"
+REGULAR_TERMINAL = "regular-terminal"
+FALLBACK_PENDING = "fallback-pending"
+FALLBACK_ACTIVE = "fallback-active"
+RECONCILING = "reconciling"
+COMPLETE = "complete"
+FAILED = "failed"
+
+_ALLOWED_TRANSITIONS = {
+    PREPARING: {REGULAR_SUBSCRIBING, FAILED},
+    REGULAR_SUBSCRIBING: {REGULAR_ACTIVE, REGULAR_TERMINAL, FAILED},
+    REGULAR_ACTIVE: {REGULAR_ACTIVE, REGULAR_TERMINAL, FAILED},
+    REGULAR_TERMINAL: {FALLBACK_PENDING, RECONCILING, FAILED},
+    FALLBACK_PENDING: {FALLBACK_ACTIVE, FAILED},
+    FALLBACK_ACTIVE: {RECONCILING, FAILED},
+    RECONCILING: {COMPLETE, FAILED},
+    COMPLETE: set(),
+    FAILED: set(),
+}
+
+_PHASES = {
+    PREPARING: "preparing-hybrid-sync",
+    REGULAR_SUBSCRIBING: "regular-subscribing",
+    REGULAR_ACTIVE: "network-catchup",
+    REGULAR_TERMINAL: "regular-terminal",
+    FALLBACK_PENDING: "fallback-pending",
+    FALLBACK_ACTIVE: "recovering-verifiable-memory",
+    RECONCILING: "reconciling-public-memory",
+    COMPLETE: "complete",
+    FAILED: "failed",
+}
+
+
+def catchup_status(payload: Any) -> str:
+    """Extract a normalized DKG job status from a route or status response."""
+    if not isinstance(payload, dict):
+        return ""
+    nested = payload.get("catchup")
+    source = nested if isinstance(nested, dict) else payload
+    return str(source.get("status") or "").strip().lower()
+
+
+def catchup_job_id(payload: Any) -> str:
+    """Extract a DKG catch-up job id from a route or status response."""
+    if not isinstance(payload, dict):
+        return ""
+    nested = payload.get("catchup")
+    source = nested if isinstance(nested, dict) else payload
+    return str(source.get("jobId") or source.get("job_id") or "").strip()
+
+
+@dataclass
+class HybridSyncCoordinator:
+    """Validate and publish one regular-first, fallback-second sync run."""
+
+    writer: Callable[..., Dict[str, Any]]
+    context_graph_id: str
+    graph_peer_id: str
+    state: str = PREPARING
+    regular_status: str = ""
+    regular_job_id: str = ""
+    fallback_reason: str = ""
+    _fallback_eligible: bool = field(default=False, init=False, repr=False)
+
+    def publish_initial(self, **details: Any) -> Dict[str, Any]:
+        return self._publish(PREPARING, **details)
+
+    def start_regular(self, **details: Any) -> Dict[str, Any]:
+        return self._transition(REGULAR_SUBSCRIBING, **details)
+
+    def observe_regular(self, payload: Any, **details: Any) -> str:
+        status = catchup_status(payload)
+        job_id = catchup_job_id(payload)
+        if job_id:
+            self.regular_job_id = job_id
+        if status:
+            self.regular_status = status
+        if status in REGULAR_ACTIVE_STATUSES:
+            self._transition(REGULAR_ACTIVE, **details)
+        elif status in REGULAR_TERMINAL_STATUSES:
+            self._fallback_eligible = status in REGULAR_FAILURE_STATUSES
+            self._transition(REGULAR_TERMINAL, **details)
+        return status
+
+    def mark_regular_empty(self, reason: str, **details: Any) -> None:
+        """Make a clean but empty terminal regular result fallback-eligible."""
+        if self.state != REGULAR_TERMINAL or self.regular_status not in REGULAR_SUCCESS_STATUSES:
+            raise RuntimeError("regular catch-up must be terminal before empty-result fallback")
+        self._fallback_eligible = True
+        self.fallback_reason = reason
+        self._publish(self.state, **details)
+
+    def queue_fallback(self, reason: str, **details: Any) -> Dict[str, Any]:
+        if self.state != REGULAR_TERMINAL or not self._fallback_eligible:
+            raise RuntimeError("fallback is forbidden while regular catch-up may still be active")
+        self.fallback_reason = reason
+        return self._transition(FALLBACK_PENDING, **details)
+
+    def start_fallback(self, **details: Any) -> Dict[str, Any]:
+        if self.state != FALLBACK_PENDING:
+            raise RuntimeError("fallback must pass through fallback-pending")
+        return self._transition(FALLBACK_ACTIVE, **details)
+
+    def start_reconciling(self, **details: Any) -> Dict[str, Any]:
+        return self._transition(RECONCILING, **details)
+
+    def complete(self, **details: Any) -> Dict[str, Any]:
+        return self._transition(COMPLETE, **details)
+
+    def fail(self, error: str, **details: Any) -> Dict[str, Any]:
+        if self.state == FAILED:
+            return self._publish(FAILED, error=error, **details)
+        return self._transition(FAILED, error=error, **details)
+
+    def _transition(self, target: str, **details: Any) -> Dict[str, Any]:
+        allowed = _ALLOWED_TRANSITIONS.get(self.state, set())
+        if target != self.state and target not in allowed:
+            raise RuntimeError(f"invalid hybrid sync transition: {self.state} -> {target}")
+        self.state = target
+        return self._publish(target, **details)
+
+    def _publish(self, state: str, **details: Any) -> Dict[str, Any]:
+        sync_mode = "none"
+        if state in {REGULAR_SUBSCRIBING, REGULAR_ACTIVE, REGULAR_TERMINAL}:
+            sync_mode = "regular"
+        elif state in {FALLBACK_PENDING, FALLBACK_ACTIVE}:
+            sync_mode = "fallback"
+        status = "running"
+        if state == COMPLETE:
+            status = "done"
+        elif state == FAILED:
+            status = "failed"
+        payload = {
+            "context_graph_id": self.context_graph_id,
+            "graph_peer_id": self.graph_peer_id,
+            "coordinator_state": state,
+            "sync_mode": sync_mode,
+            "phase": _PHASES[state],
+            **details,
+        }
+        if self.regular_status:
+            payload["regular_status"] = self.regular_status
+        if self.regular_job_id:
+            payload["regular_job_id"] = self.regular_job_id
+        if self.fallback_reason:
+            payload["fallback_reason"] = self.fallback_reason
+        return self.writer(status, **payload)

--- a/plugins/blackbox/sync_state.py
+++ b/plugins/blackbox/sync_state.py
@@ -46,7 +46,17 @@ def write(status: str, **details: Any) -> Dict[str, Any]:
         **details,
     }
     if status == "running" and previous.get("status") == "running":
-        for key in ("public_entries", "expected_public_entries", "community_entries"):
+        for key in (
+            "public_entries",
+            "expected_public_entries",
+            "community_entries",
+            "coordinator_state",
+            "sync_mode",
+            "regular_status",
+            "regular_job_id",
+            "fallback_reason",
+            "requires_dkg_restart",
+        ):
             if key not in details and key in previous:
                 state[key] = previous[key]
     if status == "running" and previous.get("status") != "running":

--- a/tests/plugins/test_blackbox_dashboard_server.py
+++ b/tests/plugins/test_blackbox_dashboard_server.py
@@ -748,6 +748,8 @@ def test_sync_activity_prefers_completed_authoritative_transfer_over_stale_conne
         "expected": 25_000,
         "percent": 100.0,
         "indeterminate": False,
+        "coordinator_state": None,
+        "sync_mode": "none",
     }
 
 

--- a/tests/plugins/test_blackbox_dkg_client.py
+++ b/tests/plugins/test_blackbox_dkg_client.py
@@ -305,6 +305,7 @@ def test_unsubscribe_context_graph_preserves_the_official_data_safe_operation(mo
     result = client.unsubscribe_context_graph("cg")
 
     assert result == {"unsubscribed": "cg", "subscribed": False}
+    assert cap["method"] == "POST"
     assert cap["url"] == "http://node/api/context-graph/unsubscribe"
     assert json.loads(cap["body"]) == {"contextGraphId": "cg"}
 

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -88,7 +88,7 @@ def test_blackbox_sync_parser_accepts_wait_timeout():
     assert args.require_rules is True
 
 
-def test_managed_sync_migrates_to_native_reconciliation_without_final_restart(
+def test_managed_sync_enables_hybrid_steady_state_without_second_restart(
     monkeypatch, tmp_path
 ):
     dkg_home = tmp_path / "dkg-home"
@@ -140,47 +140,57 @@ def test_managed_sync_migrates_to_native_reconciliation_without_final_restart(
 
     monkeypatch.setenv("BLACKBOX_HOME", str(tmp_path / "blackbox-home"))
     monkeypatch.setattr(cli_mod, "load_blackbox_config", lambda: cfg)
-    monkeypatch.setattr(cli_mod, "_restart_managed_dkg", lambda _cfg: restarts.append(True))
+    monkeypatch.setattr(
+        cli_mod,
+        "_restart_managed_dkg",
+        lambda _cfg, *, durable: restarts.append(durable),
+    )
     monkeypatch.setattr(cli_mod, "_cmd_sync_impl", sync_impl)
     monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
     monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(current))
+    monkeypatch.setattr(
+        cli_mod.sync_state,
+        "read_for_graph",
+        lambda _context_graph_id: dict(current),
+    )
 
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
     assert cli_mod._cmd_sync(args) == 0
     assert restarts == [True]
     assert [state["phase"] for state in states] == [
-        "preparing-managed-sync",
+        "preparing-hybrid-sync",
         "complete",
         "complete",
     ]
     assert states[0]["public_entries"] == 17_000
     persisted = json.loads((dkg_home / "config.json").read_text(encoding="utf-8"))
-    assert persisted["syncOnConnectEnabled"] is True
-    assert persisted["syncReconcilerEnabled"] is True
+    assert persisted["syncOnConnectEnabled"] is False
+    assert persisted["syncReconcilerEnabled"] is False
     assert persisted["durableSyncEnabled"] is True
     assert persisted["syncSharedMemoryOnConnect"] is False
     assert persisted["syncGlobalMaxInflight"] == 1
     assert persisted["syncGlobalQueueLimit"] == 0
 
 
-def test_managed_dkg_sync_environment_keeps_native_reconciliation_enabled(
+def test_managed_dkg_sync_environment_changes_only_durable_mode(
     tmp_path, monkeypatch
 ):
     (tmp_path / "daemon.pid").write_text(str(cli_mod.os.getpid()), encoding="utf-8")
     cfg = config_mod.BlackboxConfig(dkg_home=str(tmp_path))
     monkeypatch.setattr(cli_mod, "_node_runtime_matches_dkg", lambda *_args: True)
-    env = cli_mod._dkg_sync_environment(cfg)
+    active = cli_mod._dkg_sync_environment(cfg, durable=True)
+    steady = cli_mod._dkg_sync_environment(cfg, durable=False)
 
-    assert env["DKG_SYNC_ON_CONNECT_ENABLED"] == "1"
-    assert env["DKG_SYNC_RECONCILER_ENABLED"] == "1"
-    assert env["DKG_DURABLE_SYNC_ENABLED"] == "1"
-    assert env["DKG_CATCHUP_MAX_CONCURRENT_PEERS"] == "1"
-    assert env["DKG_SYNC_TOTAL_TIMEOUT_MS"] == "1800000"
-    assert env["PATH"].split(cli_mod.os.pathsep)[0] == str(
-        cli_mod.Path(cli_mod.sys.executable).resolve().parent
-    )
+    assert active["DKG_DURABLE_SYNC_ENABLED"] == "1"
+    assert steady["DKG_DURABLE_SYNC_ENABLED"] == "0"
+    assert active["DKG_CATCHUP_MAX_CONCURRENT_PEERS"] == "1"
+    assert active["DKG_SYNC_TOTAL_TIMEOUT_MS"] == "1800000"
+    assert active["PATH"].split(cli_mod.os.pathsep)[0]
+    assert active["PATH"] == steady["PATH"]
     for name, value in cli_mod._DKG_STEADY_SYNC_SETTINGS.items():
-        assert env[name] == value
+        if name != "DKG_DURABLE_SYNC_ENABLED":
+            assert active[name] == value
+            assert steady[name] == value
 
 
 def test_managed_dkg_sync_environment_finds_runtime_without_pid_file(tmp_path, monkeypatch):
@@ -201,9 +211,73 @@ def test_managed_dkg_sync_environment_finds_runtime_without_pid_file(tmp_path, m
     monkeypatch.setattr(cli_mod.psutil, "process_iter", lambda _attrs: [FakeProcess()])
     monkeypatch.setattr(cli_mod, "_node_runtime_matches_dkg", lambda *_args: True)
 
-    env = cli_mod._dkg_sync_environment(cfg)
+    env = cli_mod._dkg_sync_environment(cfg, durable=False)
 
     assert env["PATH"].split(cli_mod.os.pathsep)[0] == str(node.parent)
+
+
+def test_managed_sync_lock_drops_a_second_cli_or_dashboard_owner(monkeypatch, capsys):
+    ran = []
+
+    @cli_mod.contextmanager
+    def busy_lock():
+        yield False
+
+    monkeypatch.setattr(cli_mod, "_managed_sync_lock", busy_lock)
+    monkeypatch.setattr(cli_mod, "_cmd_sync_impl", lambda _args: ran.append(True) or 0)
+
+    result = cli_mod._cmd_sync_in_managed_window(
+        config_mod.BlackboxConfig(),
+        argparse.Namespace(wait=True, timeout=30, require_rules=True),
+    )
+
+    assert result == 2
+    assert ran == []
+    assert "already running" in capsys.readouterr().out
+
+
+def test_uncertain_fallback_is_restarted_before_regular_sync(monkeypatch):
+    current = {
+        "status": "failed",
+        "sync_mode": "fallback",
+        "requires_dkg_restart": True,
+        "public_entries": 7,
+    }
+    restarts = []
+
+    def write_state(status, **details):
+        current.clear()
+        current.update(status=status, pid=cli_mod.os.getpid(), **details)
+        return dict(current)
+
+    def sync_impl(_args):
+        write_state("done", phase="complete", public_entries=7)
+        return 0
+
+    @cli_mod.contextmanager
+    def available_lock():
+        yield True
+
+    monkeypatch.setattr(cli_mod, "_managed_sync_lock", available_lock)
+    monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(current))
+    monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
+    monkeypatch.setattr(cli_mod, "_set_persisted_dkg_steady_state", lambda _cfg: False)
+    monkeypatch.setattr(
+        cli_mod,
+        "_restart_managed_dkg",
+        lambda _cfg, *, durable: restarts.append(durable),
+    )
+    monkeypatch.setattr(cli_mod, "_cmd_sync_impl", sync_impl)
+
+    result = cli_mod._cmd_sync_in_managed_window(
+        config_mod.BlackboxConfig(),
+        argparse.Namespace(wait=True, timeout=30, require_rules=True),
+    )
+
+    assert result == 0
+    assert restarts == [True]
+    assert current["status"] == "done"
+    assert "requires_dkg_restart" not in current
 
 
 def test_blackbox_sync_require_rules_fails_empty_ruleset(monkeypatch, capsys):
@@ -472,7 +546,11 @@ def test_blackbox_sync_wait_require_rules_fails_closed_when_busy(monkeypatch, ca
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(context_graph_id="0xabc/custom-public-graph"),
     )
-    monkeypatch.setattr(cli_mod, "_uses_managed_dkg", lambda _cfg, _args: False)
+    monkeypatch.setattr(
+        cli_mod,
+        "_uses_managed_sync_window",
+        lambda _cfg, _args: False,
+    )
     monkeypatch.setattr(cli_mod, "_managed_sync_lock", BusyLock)
     monkeypatch.setattr(
         cli_mod,
@@ -707,6 +785,10 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
             events.append(("status", cg_id))
             return {"jobId": "old", "status": "done"}
 
+        def unsubscribe_context_graph(self, cg_id):
+            events.append(("unsubscribe", cg_id))
+            return {"unsubscribed": cg_id}
+
         def restart_context_graph_catchup(self, cg_id):
             events.append(("restart", cg_id))
 
@@ -758,10 +840,12 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
     assert cli_mod._cmd_sync(args) == 0
     assert len(refreshes) == 2
     assert events == [
+        ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
+        ("status", constants.DEFAULT_CONTEXT_GRAPH_ID),
+        ("unsubscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("status", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("curator", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
-        ("status", constants.DEFAULT_CONTEXT_GRAPH_ID),
     ]
     out = capsys.readouterr().out
     assert "2 public VM (curated)" in out
@@ -784,12 +868,19 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(
 
         def catchup_status(self, cg_id):
             events.append(("status", cg_id))
-            job_id = "old" if len([e for e in events if e[0] == "status"]) == 1 else "fresh"
-            return {"jobId": job_id, "status": "done"}
+            return {
+                "jobId": "fresh",
+                "status": "failed",
+                "error": "regular peers do not have the complete graph",
+            }
 
         def subscribe_context_graph(self, cg_id):
             events.append(("subscribe", cg_id))
-            return {"catchup": {"jobId": "fresh", "status": "done"}}
+            return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+        def unsubscribe_context_graph(self, cg_id):
+            events.append(("unsubscribe", cg_id))
+            return {"unsubscribed": cg_id}
 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             events.append(("curator", cg_id, peer_id, budget_ms))
@@ -871,8 +962,13 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(
         for event in curator_events
     )
     curator_indexes = [index for index, event in enumerate(events) if event[0] == "curator"]
-    assert curator_indexes[0] < events.index(("refresh",)) < curator_indexes[1]
-    assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
+    assert max(
+        index for index, event in enumerate(events) if event[0] == "status"
+    ) < curator_indexes[0]
+    assert events[0] == ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID)
+    assert len([event for event in events if event[0] == "status"]) == 3
+    assert len([event for event in events if event[0] == "subscribe"]) == 2
+    assert len([event for event in events if event[0] == "unsubscribe"]) == 1
     assert states[-1][0] == "done"
     assert states[-1][1]["public_entries"] == 23_001
     assert states[-1][1]["expected_public_entries"] == 23_001
@@ -903,6 +999,10 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
         def subscribe_context_graph(self, cg_id):
             events.append(("subscribe", cg_id))
             return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+        def unsubscribe_context_graph(self, cg_id):
+            events.append(("unsubscribe", cg_id))
+            return {"unsubscribed": cg_id}
 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             events.append(("curator", cg_id, peer_id, budget_ms))
@@ -961,10 +1061,14 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
     assert cli_mod._cmd_sync(args) == 0
     curator_events = [event for event in events if event[0] == "curator"]
     assert len(curator_events) == 1
-    assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
+    assert events[0] == ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID)
+    assert len([event for event in events if event[0] == "status"]) == 3
+    assert len([event for event in events if event[0] == "subscribe"]) == 2
+    assert len([event for event in events if event[0] == "unsubscribe"]) == 1
     assert curator_events[0][1] == constants.DEFAULT_CONTEXT_GRAPH_ID
+    # One read evaluates the terminal regular result; one indexes fallback data.
     assert len(refresh_calls) == 2
-    assert {"force_query": True} in refresh_calls
+    assert all(call == {"force_query": True} for call in refresh_calls)
     assert "25,000 public VM" in capsys.readouterr().out
 
 
@@ -1051,13 +1155,13 @@ def test_required_release_sync_fails_when_subscription_cannot_be_persisted(
     )
 
     assert result == 2
-    assert len(subscribe_calls) > 1
+    assert len(subscribe_calls) == 1
     assert state["status"] == "failed"
-    assert state["phase"] == "persisting-subscription"
+    assert state["phase"] == "regular-subscription-failed"
     assert "subscription store is unavailable" in state["error"]
     output = capsys.readouterr().out
-    assert "Required public VM subscription could not be persisted" in output
-    assert "Required ruleset sync is incomplete" in output
+    assert "regular DKG subscription failed" in output
+    assert "regular-job state is unknown" in output
 
 
 def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
@@ -1079,6 +1183,9 @@ def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
 
         def subscribe_context_graph(self, _cg_id):
             return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+        def unsubscribe_context_graph(self, cg_id):
+            return {"unsubscribed": cg_id}
 
         def catchup_from_peer(self, _cg_id, peer_id, *, budget_ms):
             return {
@@ -1138,8 +1245,7 @@ def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
     )
     output = capsys.readouterr().out
     assert "public VM returned no complete manifest boundary" in output
-    assert "Fresh DKG catch-up failed" in output
-    assert "Required ruleset sync is incomplete" in output
+    assert "Required curator fallback recovery did not complete" in output
     assert "Waiting for public VM reconciliation (0/0 entries)" not in output
 
 
@@ -1154,10 +1260,7 @@ def test_required_release_sync_persists_subscription_after_direct_connect_failur
 
         def catchup_status(self, cg_id):
             events.append(("status", cg_id))
-            return {
-                "jobId": "old" if len(events) == 1 else "fresh",
-                "status": "done" if len(events) == 1 else "failed",
-            }
+            return {"jobId": "fresh", "status": "failed"}
 
         def connect_peer(self, peer_id):
             events.append(("connect", peer_id))
@@ -1166,22 +1269,11 @@ def test_required_release_sync_persists_subscription_after_direct_connect_failur
         def catchup_from_peer(self, *_args, **_kwargs):
             raise AssertionError("catch-up must not run after connect failure")
 
-        def subscribe_context_graph(self, cg_id):
-            events.append(("subscribe", cg_id))
-            return {"catchup": {"jobId": "fresh", "status": "queued"}}
+        def subscribe_context_graph(self, *_args, **_kwargs):
+            return {"catchup": {"jobId": "fresh", "status": "failed"}}
 
-    class EmptyRuleset:
-        def counts(self):
-            return {
-                "injection": 0,
-                "escalation": 0,
-                "dependency": 0,
-                "fileaccess": 0,
-                "skill": 0,
-            }
-
-        def graph_count(self, _source):
-            return 0
+        def unsubscribe_context_graph(self, cg_id):
+            return {"unsubscribed": cg_id}
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
     monkeypatch.setattr(
@@ -1200,11 +1292,29 @@ def test_required_release_sync_persists_subscription_after_direct_connect_failur
         lambda _cfg, _client, **_kwargs: EmptyRuleset(),
     )
 
+    class EmptyRuleset:
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, _source):
+            return 0
+
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda *_args, **_kwargs: EmptyRuleset(),
+    )
+
     args = argparse.Namespace(wait=True, timeout=3_600, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
     assert len([event for event in events if event[0] == "connect"]) == 1
-    assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
-    assert "persisting the DKG subscription" in capsys.readouterr().out
+    assert "Required curator fallback recovery did not complete" in capsys.readouterr().out
 
 
 def test_authoritative_recovery_retries_fresh_node_peer_discovery(
@@ -1315,8 +1425,6 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
 
         def catchup_status(self, cg_id):
             status_calls.append(cg_id)
-            if len(status_calls) == 1:
-                return {"jobId": "old", "status": "done"}
             return {
                 "jobId": "fresh",
                 "status": "deferred",
@@ -1325,6 +1433,9 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
 
         def subscribe_context_graph(self, cg_id):
             return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+        def unsubscribe_context_graph(self, cg_id):
+            return {"unsubscribed": cg_id}
 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             curator_calls.append((cg_id, peer_id, budget_ms))
@@ -1385,9 +1496,8 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
     assert cli_mod._cmd_sync(args) == 0
     assert len(curator_calls) == 1
     assert curator_calls[0][0] == constants.DEFAULT_CONTEXT_GRAPH_ID
-    # The release graph now takes the configured curator-first path and does
-    # not wait for a generic all-peer catch-up to become terminal.
-    assert len(status_calls) == 2
+    # Deferred is terminal, so the drain gate allows the curator fallback.
+    assert len(status_calls) == 3
     assert states[-1][0] == "done"
     assert any(
         status == "running"
@@ -1439,7 +1549,149 @@ def test_blackbox_sync_does_not_fall_back_to_generic_running_catchup(monkeypatch
 
     args = argparse.Namespace(wait=True, timeout=1, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
-    assert not status_calls
+    assert status_calls
+
+
+def test_fallback_drain_gate_blocks_a_new_regular_job(monkeypatch, capsys):
+    fallback_calls = []
+    states = []
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, _cg_id):
+            return {"catchup": {"jobId": "job-1", "status": "failed"}}
+
+        def catchup_status(self, _cg_id):
+            return {"jobId": "job-2", "status": "running"}
+
+        def catchup_from_peer(self, *_args, **_kwargs):
+            fallback_calls.append(True)
+            raise AssertionError("fallback must not cross an active regular drain gate")
+
+    class EmptyRuleset:
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, _source):
+            return 0
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(
+            context_graph_id=constants.DEFAULT_CONTEXT_GRAPH_ID,
+            dkg_url=constants.DEFAULT_DKG_URL,
+            graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
+        ),
+    )
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda *_args, **_kwargs: EmptyRuleset(),
+    )
+    monkeypatch.setattr(
+        cli_mod.sync_state,
+        "write",
+        lambda status, **details: states.append((status, details)) or details,
+    )
+
+    result = cli_mod._cmd_sync_impl(
+        argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    )
+
+    assert result == 2
+    assert fallback_calls == []
+    assert states[-1][0] == "failed"
+    assert states[-1][1]["phase"] == "fallback-drain-blocked"
+    assert "curator fallback was not started" in capsys.readouterr().out
+
+
+def test_paused_subscription_drains_race_winner_before_fallback(monkeypatch):
+    events = []
+    statuses = iter(["failed", "running", "failed"])
+    refreshes = {"count": 0}
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, cg_id):
+            events.append(("subscribe", cg_id))
+            return {"catchup": {"jobId": "job-1", "status": "failed"}}
+
+        def unsubscribe_context_graph(self, cg_id):
+            events.append(("unsubscribe", cg_id))
+            return {"unsubscribed": cg_id}
+
+        def catchup_status(self, _cg_id):
+            status = next(statuses)
+            events.append(("status", status))
+            return {"jobId": "job-1", "status": status}
+
+        def catchup_from_peer(self, *_args, **_kwargs):
+            raise AssertionError("the recovery helper is replaced in this test")
+
+    class FakeRuleset:
+        def __init__(self, public):
+            self.public = public
+
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": self.public,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return self.public if source == "public" else 0
+
+    def refresh(*_args, **_kwargs):
+        refreshes["count"] += 1
+        return FakeRuleset(1 if refreshes["count"] > 1 else 0)
+
+    def fallback(*_args, **_kwargs):
+        events.append(("fallback",))
+        return True
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(cli_mod, "_catchup_authoritative_vm", fallback)
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", refresh)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(
+            context_graph_id=constants.DEFAULT_CONTEXT_GRAPH_ID,
+            dkg_url=constants.DEFAULT_DKG_URL,
+            graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
+        ),
+    )
+
+    result = cli_mod._cmd_sync_impl(
+        argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    )
+
+    assert result == 0
+    assert events == [
+        ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
+        ("status", "failed"),
+        ("unsubscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
+        ("status", "running"),
+        ("status", "failed"),
+        ("fallback",),
+        ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
+    ]
 
 
 def test_authoritative_recovery_waits_for_dkg_backpressure(
@@ -2069,10 +2321,16 @@ def test_blackbox_sync_ctrl_c_records_cancellation_and_returns_130(monkeypatch, 
             self.url = url
 
         def catchup_status(self, cg_id):
-            return {}
+            return {"jobId": "fresh", "status": "failed"}
 
         def subscribe_context_graph(self, cg_id):
-            return {}
+            return {"catchup": {"jobId": "fresh", "status": "failed"}}
+
+        def unsubscribe_context_graph(self, cg_id):
+            return {"unsubscribed": cg_id}
+
+        def connect_peer(self, _peer_id):
+            return {"connected": True}
 
         def catchup_from_peer(self, *_args, **_kwargs):
             raise KeyboardInterrupt()
@@ -2092,12 +2350,23 @@ def test_blackbox_sync_ctrl_c_records_cancellation_and_returns_130(monkeypatch, 
             graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
         ),
     )
+    class EmptyRuleset:
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, _source):
+            return 0
+
     monkeypatch.setattr(
         cli_mod.ruleset,
         "refresh",
-        lambda _cfg, _client, **_kwargs: (_ for _ in ()).throw(
-            KeyboardInterrupt()
-        ),
+        lambda _cfg, _client, **_kwargs: EmptyRuleset(),
     )
     monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
     monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(state))
@@ -2161,8 +2430,6 @@ def test_blackbox_sync_does_not_accept_stale_public_rows_after_fresh_catchup_fai
     monkeypatch, capsys
 ):
     statuses = iter([
-        {"jobId": "old", "status": "done"},
-        {"jobId": "old", "status": "done"},
         {"jobId": "fresh", "status": "failed", "error": "protocol negotiation failed"},
     ])
 
@@ -2171,13 +2438,10 @@ def test_blackbox_sync_does_not_accept_stale_public_rows_after_fresh_catchup_fai
             self.url = url
 
         def subscribe_context_graph(self, cg_id):
-            return {"catchup": {"jobId": "old", "status": "done"}}
+            return {"catchup": {"jobId": "fresh", "status": "queued"}}
 
         def catchup_status(self, cg_id):
             return next(statuses)
-
-        def restart_context_graph_catchup(self, cg_id):
-            return {"catchup": {"status": "queued"}}
 
     class FakeRuleset:
         def counts(self):
@@ -2212,7 +2476,7 @@ def test_blackbox_sync_does_not_accept_stale_public_rows_after_fresh_catchup_fai
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
     out = capsys.readouterr().out
-    assert "Required curator-pinned VM recovery is unavailable" in out
+    assert "curator fallback is unavailable" in out
 
 
 def test_blackbox_sync_uses_curator_when_generic_catchup_peer_fails(monkeypatch, capsys):
@@ -2232,6 +2496,9 @@ def test_blackbox_sync_uses_curator_when_generic_catchup_peer_fails(monkeypatch,
                 "status": "failed",
                 "error": "legacy peer protocol negotiation failed",
             }
+
+        def unsubscribe_context_graph(self, cg_id):
+            return {"unsubscribed": cg_id}
 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             events.append((cg_id, peer_id, budget_ms))

--- a/tests/plugins/test_blackbox_sync_coordinator.py
+++ b/tests/plugins/test_blackbox_sync_coordinator.py
@@ -1,0 +1,82 @@
+"""Behavior contracts for Blackbox's regular-first sync state machine."""
+
+import pytest
+
+from _blackbox_loader import load_blackbox
+
+
+coordinator_mod = load_blackbox("sync_coordinator")
+
+
+def _coordinator(events):
+    def writer(status, **details):
+        event = {"status": status, **details}
+        events.append(event)
+        return event
+
+    return coordinator_mod.HybridSyncCoordinator(writer, "owner/graph", "curator")
+
+
+def test_fallback_is_forbidden_while_regular_job_is_active():
+    events = []
+    coordinator = _coordinator(events)
+    coordinator.publish_initial()
+    coordinator.start_regular()
+    coordinator.observe_regular(
+        {"catchup": {"jobId": "job-1", "status": "running"}}
+    )
+
+    with pytest.raises(RuntimeError, match="fallback is forbidden"):
+        coordinator.queue_fallback("regular path is slow")
+
+    assert events[-1]["coordinator_state"] == coordinator_mod.REGULAR_ACTIVE
+    assert events[-1]["sync_mode"] == "regular"
+
+
+def test_terminal_regular_failure_can_cross_drain_gate_to_fallback():
+    events = []
+    coordinator = _coordinator(events)
+    coordinator.publish_initial()
+    coordinator.start_regular()
+    coordinator.observe_regular({"jobId": "job-1", "status": "failed"})
+    coordinator.queue_fallback("no regular peer had the graph")
+    coordinator.start_fallback()
+
+    assert [event["coordinator_state"] for event in events] == [
+        coordinator_mod.PREPARING,
+        coordinator_mod.REGULAR_SUBSCRIBING,
+        coordinator_mod.REGULAR_TERMINAL,
+        coordinator_mod.FALLBACK_PENDING,
+        coordinator_mod.FALLBACK_ACTIVE,
+    ]
+    assert events[-1]["sync_mode"] == "fallback"
+    assert events[-1]["regular_job_id"] == "job-1"
+
+
+def test_clean_but_empty_regular_result_must_be_explicitly_marked():
+    events = []
+    coordinator = _coordinator(events)
+    coordinator.publish_initial()
+    coordinator.start_regular()
+    coordinator.observe_regular({"jobId": "job-1", "status": "done"})
+
+    with pytest.raises(RuntimeError, match="fallback is forbidden"):
+        coordinator.queue_fallback("empty")
+
+    coordinator.mark_regular_empty("empty")
+    coordinator.queue_fallback("empty")
+    assert events[-1]["coordinator_state"] == coordinator_mod.FALLBACK_PENDING
+
+
+def test_regular_success_finishes_without_entering_fallback_mode():
+    events = []
+    coordinator = _coordinator(events)
+    coordinator.publish_initial()
+    coordinator.start_regular()
+    coordinator.observe_regular({"jobId": "job-1", "status": "done"})
+    coordinator.start_reconciling(public_entries=12)
+    coordinator.complete(public_entries=12)
+
+    assert events[-1]["status"] == "done"
+    assert events[-1]["coordinator_state"] == coordinator_mod.COMPLETE
+    assert not any(event["sync_mode"] == "fallback" for event in events)


### PR DESCRIPTION
## What does this PR do?

Blackbox now uses the local DKG node's normal context-graph subscription and catch-up as the primary threat-fetch path. A persisted `HybridSyncCoordinator` state machine and a cross-process ownership lock make the curator-pinned publisher VM path a terminal-state-only recovery fallback.

The central invariant is fail-closed mutual exclusion: fallback cannot start while regular catch-up is queued, running, or unknown. Before recovery, Blackbox re-checks terminal state, pauses the live subscription, drains any race-winning regular job, and restores the subscription when recovery stops.

## Why

The recovery-oriented flow did not have one explicit transition model governing both the regular subscriber and publisher VM recovery. That left the most important concurrency rule implicit and made dashboard progress ambiguous when background verification continued.

This change keeps DKG as the steady-state source and uses the configured publisher peer only when regular catch-up reaches a known terminal failure or finishes without queryable public threats.

## Threat fetch sequence

```mermaid
sequenceDiagram
    participant UI as Blackbox UI
    participant BB as Blackbox coordinator
    participant DKG as Local DKG node
    participant P2P as DKG network
    participant Chain as Blockchain
    participant Curator as Curator publisher

    UI->>BB: Start or poll threat sync
    BB->>BB: Acquire cross-process ownership
    BB->>DKG: Subscribe to threat context graph
    DKG->>Chain: Resolve graph verification state
    DKG->>P2P: Gossip and regular CG catch-up
    DKG-->>BB: queued, running, or terminal status

    alt done and public threats are queryable
        BB->>DKG: Refresh verified threat rules
        BB-->>UI: complete
    else terminal failure or done-but-empty
        BB->>DKG: Re-check terminal drain gate
        BB->>DKG: Unsubscribe and pause live CG reconciliation
        loop Until any race-winning regular job is terminal
            BB->>DKG: Poll catch-up status
        end
        BB->>DKG: Start curator-pinned peer recovery
        DKG->>Curator: Fetch publisher VM snapshot
        DKG->>Chain: Verify and reconcile graph state
        DKG-->>BB: Verified threats become queryable
        BB->>DKG: Restore normal graph subscription
        BB-->>UI: complete
    end
```

## State-machine and concurrency guarantees

- one cross-process owner runs a Blackbox sync window at a time
- fallback is rejected from `regular-subscribing`, `regular-active`, or unknown job state
- fallback must pass through `regular-terminal` and `fallback-pending`
- a pre-pause gate detects newly started regular work; a post-pause gate drains work that won the race before unsubscribe
- failure to prove a terminal drain aborts fallback and restores the subscription when safe
- uncertain publisher requests persist `requires_dkg_restart`; the next managed sync restarts DKG before either path starts
- successful or safely failed fallback restores regular subscription, preserving DKG as the steady-state source

## Changes made

- add `plugins/blackbox/sync_coordinator.py` with explicit allowed transitions and persisted progress payloads
- rework release-graph sync in `plugins/blackbox/cli.py` into a regular-first hybrid flow
- add explicit context-graph unsubscribe support to `DkgClient`
- preserve coordinator state, sync mode, regular job metadata, fallback reason, and restart requirements in `sync_state`
- update dashboard activity labels and terminal-state handling
- document normal subscription and curator recovery behavior
- add behavior tests for transition guards, drain races, subscription restoration, restart recovery, and UI state

## User impact

- initial and ongoing threat updates use the local DKG node and normal context-graph mechanisms
- curator recovery remains available for terminal regular failures and clean-but-empty results
- dashboard progress distinguishes regular subscription, network catch-up, terminal evaluation, fallback handoff, publisher recovery, reconciliation, and completion

## Validation

- Blackbox test suite: **375 passed, 5 skipped**
- `git diff --check`

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Tests
- [x] Documentation

## Checklist

- [x] Commit uses Conventional Commits
- [x] Changes are scoped to Blackbox threat-graph synchronization
- [x] Tests cover the new state-machine and concurrency invariants
- [x] Relevant Blackbox documentation is updated
