### PR TITLE
fix(blackbox): sync configured VM graph directly

### DIFF
--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -41,7 +41,6 @@ _BLACKBOX_SOUL_MARKER = "<!-- managed-by: hermes-blackbox-chat -->"
 _LEGACY_MANAGED_SOUL_PREFIX = "<!-- managed-by: hermes-"
 _BLACKBOX_SOURCE_ROOT_MARKER = ".blackbox-source-root"
 _BLACKBOX_CONTEXT_FILE_MAX_CHARS = 100_000
-_MAX_GRAPH_METADATA_PASSES = 5
 _MAX_EMPTY_PUBLIC_PASSES = 3
 _BLACKBOX_SOUL = f"""{_BLACKBOX_SOUL_MARKER}
 # Agent Blackbox
@@ -1278,56 +1277,6 @@ def _ruleset_graph_count(rs: Any, source: str) -> int:
     return sum(int(value or 0) for value in rs.counts().values())
 
 
-def _context_graph_on_chain_binding(
-    client: DkgClient,
-    context_graph_id: str,
-) -> Optional[str]:
-    """Read a cleartext graph's numeric chain binding from DKG's registry."""
-    if not context_graph_id or any(
-        char.isspace() or char in '<>"{}|^`\\'
-        for char in context_graph_id
-    ):
-        return None
-    try:
-        rows = client.context_graphs()
-    except (AttributeError, DkgError):
-        rows = []
-    for row in rows:
-        if str(row.get("id") or "") != context_graph_id:
-            continue
-        value = str(row.get("onChainId") or "").strip()
-        try:
-            return value if value.isdigit() and int(value) > 0 else None
-        except ValueError:
-            return None
-
-    # Fresh DKG nodes can have the verified ontology triples locally before
-    # /api/context-graph/list has materialized its registry entry. Query that
-    # authoritative graph directly instead of treating the derived list as the
-    # only completion signal.
-    subject = f"did:dkg:context-graph:{context_graph_id}"
-    sparql = (
-        "SELECT ?onChainId WHERE { "
-        f"<{subject}> "
-        "<https://dkg.network/ontology#ContextGraphOnChainId> "
-        "?onChainId . } LIMIT 1"
-    )
-    try:
-        rows = client.query(
-            sparql,
-            constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID,
-            view=constants.VIEW_VERIFIABLE_MEMORY,
-            on_error=[],
-        )
-    except AttributeError:
-        return None
-    for row in rows:
-        value = str(row.get("onChainId") or "").strip()
-        if value.isdigit() and int(value) > 0:
-            return value
-    return None
-
-
 def _catchup_authoritative_vm(
     client: DkgClient,
     context_graph_id: str,
@@ -1365,30 +1314,12 @@ def _catchup_authoritative_vm(
         print(f"  {error}")
         return False
 
-    # A fresh DKG edge does not yet know the cleartext graph id's numeric
-    # on-chain binding. The small system ontology graph carries that standard
-    # DKG metadata. Fetch it from the same source first so the VM verifier can
-    # authenticate each graph-scoped assertion as soon as it arrives.
-    pending_context_graphs = [context_graph_id]
-    existing_on_chain_id = _context_graph_on_chain_binding(client, context_graph_id)
-    if (
-        context_graph_id == constants.DEFAULT_CONTEXT_GRAPH_ID
-        and existing_on_chain_id is None
-    ):
-        pending_context_graphs.insert(
-            0,
-            constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID,
-        )
-    elif existing_on_chain_id is not None:
-        print(
-            "  verified graph metadata ready "
-            f"(context graph {existing_on_chain_id})"
-        )
+    # DKG authenticates the configured graph id against its on-chain name-hash
+    # commitment. Request that graph directly instead of making VM availability
+    # depend on a separately materialized ontology graph.
     public_progress_seen = False
-    metadata_passes = 0
 
-    while pending_context_graphs:
-        active_context_graph_id = pending_context_graphs[0]
+    while True:
         remaining = deadline - time.monotonic()
         if remaining <= 1:
             sync_state.write(
@@ -1421,7 +1352,7 @@ def _catchup_authoritative_vm(
             def _recover() -> None:
                 try:
                     outcome.put(("ok", catchup(
-                        active_context_graph_id,
+                        context_graph_id,
                         graph_peer_id,
                         budget_ms=budget_ms,
                     )))
@@ -1552,51 +1483,6 @@ def _catchup_authoritative_vm(
             return False
         backpressure_retries = 0
         inserted = int(result.get("totalDurableInsertedTriples") or 0)
-        if active_context_graph_id != context_graph_id:
-            metadata_passes += 1
-            on_chain_id = _context_graph_on_chain_binding(
-                client,
-                context_graph_id,
-            )
-            if on_chain_id is not None:
-                print(f"  verified graph metadata ready (context graph {on_chain_id})")
-                pending_context_graphs.pop(0)
-                backpressure_retries = 0
-                continue
-            if inserted > 0:
-                if metadata_passes >= _MAX_GRAPH_METADATA_PASSES:
-                    error = (
-                        "verified graph metadata did not expose a numeric "
-                        f"context-graph binding after {metadata_passes} passes"
-                    )
-                    sync_state.write(
-                        "failed",
-                        context_graph_id=context_graph_id,
-                        graph_peer_id=graph_peer_id,
-                        phase="resolving-context-graph-binding",
-                        error=error,
-                    )
-                    print(f"  {error}; refusing the public VM transfer")
-                    return False
-                print(
-                    f"  verified graph metadata advanced "
-                    f"({inserted:,} triples received)"
-                )
-                time.sleep(min(1.0, max(0.2, deadline - time.monotonic())))
-                continue
-            error = (
-                "verified graph metadata settled without a numeric "
-                "context-graph binding"
-            )
-            sync_state.write(
-                "failed",
-                context_graph_id=context_graph_id,
-                graph_peer_id=graph_peer_id,
-                phase="resolving-context-graph-binding",
-                error=error,
-            )
-            print(f"  {error}; refusing the public VM transfer")
-            return False
         sync_state.write(
             "running",
             context_graph_id=context_graph_id,

--- a/plugins/blackbox/constants.py
+++ b/plugins/blackbox/constants.py
@@ -110,14 +110,10 @@ DEFAULT_DKG_URL = f"http://127.0.0.1:{DEFAULT_DKG_PORT}"
 #: Source peer used for verified catch-up of the default threat graph.
 DEFAULT_GRAPH_PEER_ID = "12D3KooWBJskzr2unXQG9mR3LRZFUJoxWr1PN6hTbyWyKndHXjZM"
 
-#: DKG system graph that carries the cleartext graph id -> on-chain id binding.
-#: A fresh client fetches this small graph before the large VM so graph-scoped
-#: assertions can be verified immediately instead of being downloaded and then
-#: rejected as an unresolved context graph.
-DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID = "ontology"
-
-#: Keep the first pass short so a fresh install gets prompt feedback. Durable
-#: progress is resumable; later passes use the normal, longer DKG budget.
+#: Keep the first durable recovery request short so a fresh install gets a
+#: useful verified ruleset quickly. DKG checkpoints complete exact graphs and
+#: resumes the next request from the safe boundary, so this does not weaken
+#: verification.
 INITIAL_GRAPH_SYNC_PASS_BUDGET_MS = 30_000
 
 #: Once the first verified rules are locally usable, prefer DKG's normal

--- a/plugins/blackbox/dkg_version.py
+++ b/plugins/blackbox/dkg_version.py
@@ -1,0 +1,36 @@
+"""DKG runtime compatibility required by Blackbox recovery."""
+
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+
+MINIMUM_DKG_VERSION = (10, 0, 9)
+MINIMUM_DKG_VERSION_TEXT = ".".join(str(part) for part in MINIMUM_DKG_VERSION)
+
+
+def parse_dkg_version(raw: str) -> tuple[int, int, int] | None:
+    """Parse the numeric core of an npm semantic version."""
+    core = str(raw or "").strip().split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        return None
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+def supports_direct_vm_sync(raw: str) -> bool:
+    """Return whether a DKG release contains direct chain-name verification."""
+    parsed = parse_dkg_version(raw)
+    return parsed is not None and parsed >= MINIMUM_DKG_VERSION
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        return 2
+    return 0 if supports_direct_vm_sync(args[0]) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/blackbox-install.ps1
+++ b/scripts/blackbox-install.ps1
@@ -1040,14 +1040,9 @@ function Install-BlackboxDkgPackage {
         Write-Warn2 "Could not determine the installed DKG package version."
         return $false
     }
-    try {
-        $numericVersion = [version](($installedVersion -split '-', 2)[0])
-    } catch {
-        Write-Warn2 "Could not parse installed DKG package version $installedVersion."
-        return $false
-    }
-    if ($numericVersion -lt [version]"10.0.7") {
-        Write-Warn2 "DKG $installedVersion is too old for the complete Blackbox graph; version 10.0.7+ is required."
+    & $script:VenvPython -m plugins.blackbox.dkg_version $installedVersion
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn2 "DKG $installedVersion is too old for direct verified Blackbox recovery; version 10.0.9+ is required."
         return $false
     }
     Write-Step "Using published upstream DKG $installedVersion unchanged."

--- a/scripts/blackbox-install.sh
+++ b/scripts/blackbox-install.sh
@@ -1330,18 +1330,8 @@ install_blackbox_dkg_package() {
         warn "Could not determine the installed DKG package version."
         return 1
     fi
-    if ! "$VENV_DIR/bin/python" - "$installed_version" <<'PYEOF'
-import sys
-
-raw = sys.argv[1].split("-", 1)[0]
-try:
-    version = tuple(int(part) for part in raw.split("."))
-except ValueError:
-    raise SystemExit(1)
-raise SystemExit(0 if version >= (10, 0, 7) else 1)
-PYEOF
-    then
-        warn "DKG $installed_version is too old for the complete Blackbox graph; version 10.0.7+ is required."
+    if ! "$VENV_DIR/bin/python" -m plugins.blackbox.dkg_version "$installed_version"; then
+        warn "DKG $installed_version is too old for direct verified Blackbox recovery; version 10.0.9+ is required."
         return 1
     fi
     step "Using published upstream DKG $installed_version unchanged."

--- a/tests/plugins/test_blackbox_dkg_version.py
+++ b/tests/plugins/test_blackbox_dkg_version.py
@@ -1,0 +1,29 @@
+"""Behavioral tests for the Blackbox DKG runtime gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.blackbox import dkg_version
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("10.0.8", False),
+        ("10.0.9", True),
+        ("10.0.9-rc.1", True),
+        ("10.0.10", True),
+        ("11.0.0", True),
+        ("not-a-version", False),
+        ("10.0", False),
+    ],
+)
+def test_direct_vm_runtime_gate(version: str, expected: bool) -> None:
+    assert dkg_version.supports_direct_vm_sync(version) is expected
+
+
+def test_runtime_gate_cli_exit_status() -> None:
+    assert dkg_version.main(["10.0.8"]) == 1
+    assert dkg_version.main(["10.0.9"]) == 0
+    assert dkg_version.main([]) == 2

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -324,9 +324,6 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
         return FakeRuleset(public=2 if len(refreshes) > 1 else 0)
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
-    monkeypatch.setattr(
-        cli_mod, "_context_graph_on_chain_binding", lambda *_args: "14"
-    )
     monkeypatch.setattr(cli_mod, "_request_join", lambda *args: ("already approved", True))
     monkeypatch.setattr(
         cli_mod,
@@ -409,9 +406,6 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, 
 
     states = []
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
-    monkeypatch.setattr(
-        cli_mod, "_context_graph_on_chain_binding", lambda *_args: "14"
-    )
     monkeypatch.setattr(cli_mod, "_request_join", lambda *args: ("already approved", True))
     monkeypatch.setattr(cli_mod.sync_state, "write", lambda status, **data: states.append((status, data)))
     monkeypatch.setattr(
@@ -440,8 +434,10 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, 
     assert cli_mod._cmd_sync(args) == 0
     curator_events = [event for event in events if event[0] == "curator"]
     assert len(curator_events) == 3
-    assert curator_events[0][1] == constants.DEFAULT_CONTEXT_GRAPH_ID
-    assert curator_events[1][1] == constants.DEFAULT_CONTEXT_GRAPH_ID
+    assert all(
+        event[1] == constants.DEFAULT_CONTEXT_GRAPH_ID
+        for event in curator_events
+    )
     curator_indexes = [index for index, event in enumerate(events) if event[0] == "curator"]
     assert curator_indexes[0] < events.index(("refresh",)) < curator_indexes[1]
     assert not any(event[0] == "subscribe" for event in events)
@@ -507,9 +503,6 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
     monkeypatch.setattr(
-        cli_mod, "_context_graph_on_chain_binding", lambda *_args: "14"
-    )
-    monkeypatch.setattr(
         cli_mod,
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(
@@ -573,9 +566,6 @@ def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
             return 0
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
-    monkeypatch.setattr(
-        cli_mod, "_context_graph_on_chain_binding", lambda *_args: "14"
-    )
     monkeypatch.setattr(
         cli_mod,
         "load_blackbox_config",
@@ -777,9 +767,6 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
     monkeypatch.setattr(
-        cli_mod, "_context_graph_on_chain_binding", lambda *_args: "14"
-    )
-    monkeypatch.setattr(
         cli_mod,
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(
@@ -899,9 +886,7 @@ def test_authoritative_recovery_waits_for_dkg_backpressure(monkeypatch, capsys):
     assert "pausing briefly before a safe resume" in capsys.readouterr().out
 
 
-def test_authoritative_recovery_uses_short_first_pass_then_normal_dkg_budget(
-    monkeypatch,
-):
+def test_authoritative_recovery_syncs_target_directly_with_bounded_budgets(monkeypatch):
     budgets = []
     graph_calls = []
     durable_rounds = iter([10_134, 250_000, 500_000, 0])
@@ -921,7 +906,10 @@ def test_authoritative_recovery_uses_short_first_pass_then_normal_dkg_budget(
             }
 
         def context_graphs(self):
-            return [{"id": constants.DEFAULT_CONTEXT_GRAPH_ID, "onChainId": "14"}]
+            raise AssertionError("direct recovery must not inspect the local CG registry")
+
+        def query(self, *_args, **_kwargs):
+            raise AssertionError("direct recovery must not query an ontology graph")
 
     monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
@@ -938,12 +926,7 @@ def test_authoritative_recovery_uses_short_first_pass_then_normal_dkg_budget(
         constants.DEFAULT_GRAPH_SYNC_PASS_BUDGET_MS,
         constants.DEFAULT_GRAPH_SYNC_PASS_BUDGET_MS,
     ]
-    assert graph_calls == [
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-    ]
+    assert graph_calls == [constants.DEFAULT_CONTEXT_GRAPH_ID] * 4
 
 
 def test_authoritative_recovery_stops_after_safe_manifest_completion(
@@ -1068,81 +1051,9 @@ def test_authoritative_recovery_bounds_empty_fresh_public_passes(
     assert "after 3 pinned passes" in capsys.readouterr().out
 
 
-def test_context_graph_binding_falls_back_to_verified_ontology_query():
-    calls = []
-
-    class FakeClient:
-        def context_graphs(self):
-            return []
-
-        def query(self, sparql, cg_id, *, view, on_error):
-            calls.append((sparql, cg_id, view, on_error))
-            return [{"onChainId": "14"}]
-
-    assert cli_mod._context_graph_on_chain_binding(
-        FakeClient(), constants.DEFAULT_CONTEXT_GRAPH_ID
-    ) == "14"
-    assert calls == [(
-        "SELECT ?onChainId WHERE { "
-        f"<did:dkg:context-graph:{constants.DEFAULT_CONTEXT_GRAPH_ID}> "
-        "<https://dkg.network/ontology#ContextGraphOnChainId> "
-        "?onChainId . } LIMIT 1",
-        constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID,
-        constants.VIEW_VERIFIABLE_MEMORY,
-        [],
-    )]
-
-
-def test_authoritative_recovery_advances_when_repeated_metadata_has_binding(
+def test_authoritative_recovery_fails_closed_on_direct_graph_verification_error(
     monkeypatch,
 ):
-    graph_calls = []
-    binding_queries = 0
-
-    class FakeClient:
-        def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
-            graph_calls.append(cg_id)
-            return {
-                "ok": True,
-                "includeDurable": True,
-                "includeSharedMemory": False,
-                "peersAttempted": 1,
-                "totalDurableInsertedTriples": (
-                    10_134
-                    if cg_id == constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID
-                    else 0
-                ),
-                "results": [{"peerId": peer_id}],
-            }
-
-        def context_graphs(self):
-            return []
-
-        def query(self, _sparql, cg_id, *, view, on_error):
-            nonlocal binding_queries
-            assert cg_id == constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID
-            assert view == constants.VIEW_VERIFIABLE_MEMORY
-            assert on_error == []
-            binding_queries += 1
-            return [{"onChainId": "14"}] if binding_queries == 3 else []
-
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
-
-    assert cli_mod._catchup_authoritative_vm(
-        FakeClient(),
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_GRAPH_PEER_ID,
-        cli_mod.time.monotonic() + 600,
-    )
-    assert graph_calls == [
-        constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-    ]
-
-
-def test_authoritative_recovery_bounds_missing_metadata_binding(monkeypatch):
     graph_calls = []
     states = []
 
@@ -1150,21 +1061,22 @@ def test_authoritative_recovery_bounds_missing_metadata_binding(monkeypatch):
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             graph_calls.append(cg_id)
             return {
-                "ok": True,
+                "ok": False,
                 "includeDurable": True,
                 "includeSharedMemory": False,
                 "peersAttempted": 1,
-                "totalDurableInsertedTriples": 10_134,
-                "results": [{"peerId": peer_id}],
+                "totalDurableInsertedTriples": 0,
+                "results": [
+                    {
+                        "peerId": peer_id,
+                        "durableError": (
+                            "VM_CHAIN_CONTEXT_GRAPH_MISMATCH: "
+                            "context graph commitment did not match"
+                        ),
+                    }
+                ],
             }
 
-        def context_graphs(self):
-            return []
-
-        def query(self, *_args, **_kwargs):
-            return []
-
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         cli_mod.sync_state,
         "write",
@@ -1175,43 +1087,11 @@ def test_authoritative_recovery_bounds_missing_metadata_binding(monkeypatch):
         FakeClient(),
         constants.DEFAULT_CONTEXT_GRAPH_ID,
         constants.DEFAULT_GRAPH_PEER_ID,
-        cli_mod.time.monotonic() + 600,
-    )
-    assert graph_calls == [
-        constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID
-    ] * cli_mod._MAX_GRAPH_METADATA_PASSES
-    assert states[-1][0] == "failed"
-    assert states[-1][1]["phase"] == "resolving-context-graph-binding"
-
-
-def test_authoritative_recovery_requires_binding_before_public_vm(monkeypatch, capsys):
-    graph_calls = []
-
-    class FakeClient:
-        def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
-            graph_calls.append(cg_id)
-            return {
-                "ok": True,
-                "includeDurable": True,
-                "includeSharedMemory": False,
-                "peersAttempted": 1,
-                "totalDurableInsertedTriples": 0,
-                "results": [{"peerId": peer_id}],
-            }
-
-        def context_graphs(self):
-            return []
-
-    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
-
-    assert not cli_mod._catchup_authoritative_vm(
-        FakeClient(),
-        constants.DEFAULT_CONTEXT_GRAPH_ID,
-        constants.DEFAULT_GRAPH_PEER_ID,
         cli_mod.time.monotonic() + 60,
     )
-    assert graph_calls == [constants.DEFAULT_GRAPH_METADATA_CONTEXT_GRAPH_ID]
-    assert "refusing the public VM transfer" in capsys.readouterr().out
+    assert graph_calls == [constants.DEFAULT_CONTEXT_GRAPH_ID]
+    assert states[-1][0] == "failed"
+    assert "VM_CHAIN_CONTEXT_GRAPH_MISMATCH" in states[-1][1]["error"]
 
 
 def test_authoritative_recovery_does_not_loop_when_dkg_attempts_no_peer(monkeypatch):
@@ -1476,9 +1356,6 @@ def test_blackbox_sync_uses_curator_when_generic_catchup_peer_fails(monkeypatch,
             return [{"identifier": "dep:2"}]
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
-    monkeypatch.setattr(
-        cli_mod, "_context_graph_on_chain_binding", lambda *_args: "14"
-    )
     monkeypatch.setattr(cli_mod, "_request_join", lambda *args: ("already approved", True))
     monkeypatch.setattr(
         cli_mod,


### PR DESCRIPTION
## Summary

- request the configured threat VM context graph directly from the curator
- remove the ontology-prefetch and local numeric-binding precondition
- preserve fail-closed handling when DKG rejects chain verification

## Why

A cold Blackbox node can reach the curator while its local ontology graph has no materialized context-graph binding. Blackbox currently treats that missing derived metadata as proof that the public VM cannot be authenticated and refuses to request the configured threat graph at all.

DKG is the component responsible for authenticating the requested cleartext context-graph id against its on-chain name-hash commitment. Blackbox should request its configured graph directly and consume DKG success or failure.

## Dependency

This change must be released with the corresponding DKG direct name-hash verifier fix. Current DKG 10.0.8 can still reject a cold direct transfer as an unresolved context graph.

## Verification

- scripts/run_tests.sh tests/plugins/test_blackbox_plugin.py -q: 48 passed
- all 23 Blackbox-related test files: 481 passed, 0 failed
- ruff check: passed
- git diff --check: passed