### PR TITLE
fix(blackbox): let durable sync batches settle

### DIFF
--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -1365,9 +1365,18 @@ def _catchup_authoritative_vm(
                 daemon=True,
             )
             worker.start()
+            request_started = time.monotonic()
             request_deadline = min(
                 deadline,
-                time.monotonic() + (budget_ms / 1_000) + 60.0,
+                request_started
+                + max(
+                    (budget_ms / 1_000) + 60.0,
+                    constants.GRAPH_SYNC_SETTLEMENT_TIMEOUT_S,
+                ),
+            )
+            request_timeout_seconds = max(
+                1,
+                int(request_deadline - request_started),
             )
             heartbeat = 0
             while True:
@@ -1377,8 +1386,8 @@ def _catchup_authoritative_vm(
                 )
                 if wait_for <= 0:
                     raise DkgError(
-                        f"verifiable VM sync exceeded its "
-                        f"{budget_ms / 1_000:.0f}s request budget"
+                        "verifiable VM sync exceeded its "
+                        f"{request_timeout_seconds}s settlement deadline"
                     )
                 try:
                     outcome_kind, outcome_value = outcome.get(timeout=wait_for)
@@ -1494,7 +1503,30 @@ def _catchup_authoritative_vm(
             ),
             inserted_durable_triples=inserted,
         )
+        durable_progress = read_durable_progress(
+            str(getattr(client, "dkg_home", "") or ""),
+            context_graph_id,
+        )
         if inserted <= 0:
+            expected = int(durable_progress.get("expected_triples") or 0)
+            safe_current = int(durable_progress.get("safe_current_triples") or 0)
+            if expected > 0 and safe_current < expected:
+                public_progress_seen = public_progress_seen or safe_current > 0
+                sync_state.write(
+                    "running",
+                    context_graph_id=context_graph_id,
+                    graph_peer_id=graph_peer_id,
+                    phase="recovering-verifiable-memory",
+                    inserted_durable_triples=0,
+                    **durable_progress,
+                )
+                print(
+                    "  verifiable VM pass settled without committed triples; "
+                    f"snapshot remains incomplete ({safe_current:,}/{expected:,}); "
+                    "retrying the pinned source"
+                )
+                time.sleep(min(2.0, max(0.2, deadline - time.monotonic())))
+                continue
             count_threats = getattr(client, "threat_count", None)
             local_threats: Optional[int] = None
             if callable(count_threats):
@@ -1541,10 +1573,6 @@ def _catchup_authoritative_vm(
         # only after verification and store materialization settle, so combine
         # that successful response with the managed daemon's safe graph boundary
         # to recognize completion without downloading the snapshot again.
-        durable_progress = read_durable_progress(
-            str(getattr(client, "dkg_home", "") or ""),
-            context_graph_id,
-        )
         if durable_progress.get("snapshot_complete") is True:
             expected = int(durable_progress.get("expected_triples") or 0)
             sync_state.write(
@@ -1576,6 +1604,9 @@ def _peer_discovery_pending(exc: DkgError) -> bool:
             "peerresolver returned no addresses",
             "no addresses for",
             "failed to find peer",
+            "dial_failed",
+            "all multiaddr dials failed",
+            "transport error: timed out",
         )
     )
 

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -1299,6 +1299,8 @@ def _catchup_authoritative_vm(
     backpressure_notice_printed = False
     backpressure_retries = 0
     empty_public_passes = 0
+    incomplete_empty_passes = 0
+    last_incomplete_safe_current: Optional[int] = None
     heartbeat_seconds = 10.0
 
     try:
@@ -1341,6 +1343,7 @@ def _catchup_authoritative_vm(
                 int(max(1.0, remaining - 10) * 1_000),
             ),
         )
+        request_still_active = False
         try:
             # The DKG endpoint is synchronous and its final verification/store
             # phase can outlive a socket inactivity timeout. Run it behind a
@@ -1371,7 +1374,8 @@ def _catchup_authoritative_vm(
                 request_started
                 + max(
                     (budget_ms / 1_000) + 60.0,
-                    constants.GRAPH_SYNC_SETTLEMENT_TIMEOUT_S,
+                    constants.GRAPH_SYNC_SETTLEMENT_TIMEOUT_S
+                    + constants.GRAPH_SYNC_WATCHDOG_HEADROOM_S,
                 ),
             )
             request_timeout_seconds = max(
@@ -1385,9 +1389,15 @@ def _catchup_authoritative_vm(
                     max(0.0, request_deadline - time.monotonic()),
                 )
                 if wait_for <= 0:
+                    request_still_active = worker.is_alive()
                     raise DkgError(
-                        "verifiable VM sync exceeded its "
+                        "verifiable VM sync watchdog reached its "
                         f"{request_timeout_seconds}s settlement deadline"
+                        + (
+                            " while the DKG request remains active"
+                            if request_still_active
+                            else ""
+                        )
                     )
                 try:
                     outcome_kind, outcome_value = outcome.get(timeout=wait_for)
@@ -1411,7 +1421,7 @@ def _catchup_authoritative_vm(
             result = outcome_value
         except DkgError as exc:
             error = str(exc)
-            retryable = any(
+            retryable = not request_still_active and any(
                 marker in error.lower()
                 for marker in (
                     "backpressure",
@@ -1512,6 +1522,31 @@ def _catchup_authoritative_vm(
             safe_current = int(durable_progress.get("safe_current_triples") or 0)
             if expected > 0 and safe_current < expected:
                 public_progress_seen = public_progress_seen or safe_current > 0
+                if (
+                    last_incomplete_safe_current is None
+                    or safe_current > last_incomplete_safe_current
+                ):
+                    incomplete_empty_passes = 1
+                else:
+                    incomplete_empty_passes += 1
+                last_incomplete_safe_current = safe_current
+                if incomplete_empty_passes >= _MAX_EMPTY_PUBLIC_PASSES:
+                    error = (
+                        "public VM manifest made no durable progress after "
+                        f"{incomplete_empty_passes} pinned passes "
+                        f"({safe_current:,}/{expected:,})"
+                    )
+                    sync_state.write(
+                        "failed",
+                        context_graph_id=context_graph_id,
+                        graph_peer_id=graph_peer_id,
+                        phase="stalled-verifiable-memory",
+                        inserted_durable_triples=0,
+                        error=error,
+                        **durable_progress,
+                    )
+                    print(f"  {error}")
+                    return False
                 sync_state.write(
                     "running",
                     context_graph_id=context_graph_id,
@@ -1562,6 +1597,10 @@ def _catchup_authoritative_vm(
             print("  verifiable VM sync settled (no new triples)")
             return True
         empty_public_passes = 0
+        incomplete_empty_passes = 0
+        last_incomplete_safe_current = int(
+            durable_progress.get("safe_current_triples") or 0
+        )
         print(f"  verifiable VM sync advanced ({inserted:,} triples inserted)")
         if on_progress is not None:
             on_progress(inserted)

--- a/plugins/blackbox/constants.py
+++ b/plugins/blackbox/constants.py
@@ -129,6 +129,11 @@ DEFAULT_GRAPH_SYNC_PASS_BUDGET_MS = 60_000
 #: the fetch budget.
 GRAPH_SYNC_SETTLEMENT_TIMEOUT_S = 3_600.0
 
+#: Let the HTTP client report its own timeout before the outer CLI watchdog
+#: fires. This prevents a retry from overlapping a request that is still
+#: blocked inside urllib at the settlement boundary.
+GRAPH_SYNC_WATCHDOG_HEADROOM_S = 15.0
+
 #: Previous bootstrap peers transparently replaced during config loading.
 LEGACY_GRAPH_PEER_IDS = frozenset({
     "12D3KooWAuEHYTWbD3R3yPTcECCYZnrjHNpJmrUw5b4D5T3m5Kr3",

--- a/plugins/blackbox/constants.py
+++ b/plugins/blackbox/constants.py
@@ -116,10 +116,18 @@ DEFAULT_GRAPH_PEER_ID = "12D3KooWBJskzr2unXQG9mR3LRZFUJoxWr1PN6hTbyWyKndHXjZM"
 #: verification.
 INITIAL_GRAPH_SYNC_PASS_BUDGET_MS = 30_000
 
-#: Once the first verified rules are locally usable, prefer DKG's normal
-#: per-peer durable budget. Larger follow-up passes avoid repeatedly paying the
-#: metadata/session/verification overhead that made complete fresh syncs slow.
-DEFAULT_GRAPH_SYNC_PASS_BUDGET_MS = 110_000
+#: Keep follow-up batches small enough for exact-graph verification and atomic
+#: materialization to finish before DKG's ten-minute responder session expires.
+#: A larger fetch can settle successfully but still lose its numeric checkpoint
+#: before the next pass, forcing the snapshot back to offset zero.
+DEFAULT_GRAPH_SYNC_PASS_BUDGET_MS = 60_000
+
+#: Durable network fetching is bounded by the pass budget above, but DKG must
+#: still verify complete graphs and atomically materialize them afterward. A
+#: large fresh-node pass can spend many minutes in that correctness-critical
+#: settlement phase, so the HTTP caller and its watchdog must wait longer than
+#: the fetch budget.
+GRAPH_SYNC_SETTLEMENT_TIMEOUT_S = 3_600.0
 
 #: Previous bootstrap peers transparently replaced during config loading.
 LEGACY_GRAPH_PEER_IDS = frozenset({

--- a/plugins/blackbox/dkg_client.py
+++ b/plugins/blackbox/dkg_client.py
@@ -299,10 +299,14 @@ class DkgClient:
                 "hostCatchupFallback": False,
                 "perPeerDurableBudgetMs": bounded_budget,
             },
-            # DKG may need a short finalization window after its bounded data
-            # phase records resumable progress. Do not let the HTTP client
-            # abandon that response at the exact data-phase boundary.
-            timeout=(bounded_budget / 1_000) + 45,
+            # The budget bounds network fetching, not exact-graph verification
+            # and atomic store materialization. Large fresh-node batches can
+            # spend many minutes settling after the fetch deadline, and the
+            # route deliberately waits for that work before responding.
+            timeout=max(
+                (bounded_budget / 1_000) + 45,
+                constants.GRAPH_SYNC_SETTLEMENT_TIMEOUT_S,
+            ),
         )
 
     def context_graph_participants(self, cg_id: str) -> Dict[str, Any]:

--- a/tests/plugins/test_blackbox_dkg_client.py
+++ b/tests/plugins/test_blackbox_dkg_client.py
@@ -194,7 +194,7 @@ def test_authoritative_catchup_pins_publisher_for_durable_vm_recovery(monkeypatc
         "hostCatchupFallback": False,
         "perPeerDurableBudgetMs": 300_000,
     }
-    assert cap["timeout"] == 345
+    assert cap["timeout"] == dkg_client.constants.GRAPH_SYNC_SETTLEMENT_TIMEOUT_S
 
 
 def test_context_graph_has_agent_uses_local_participants_metadata(monkeypatch):

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -650,8 +650,8 @@ def test_authoritative_recovery_retries_fresh_node_peer_discovery(monkeypatch, c
             connects.append(peer_id)
             if len(connects) == 1:
                 raise cli_mod.DkgError(
-                    'POST /api/connect -> 404: {"code":"PEER_NOT_FOUND",'
-                    '"error":"PeerResolver returned no addresses"}'
+                    'POST /api/connect -> 502: {"code":"DIAL_FAILED",'
+                    '"error":"All multiaddr dials failed"}'
                 )
             return {"connected": True}
 
@@ -1014,6 +1014,54 @@ def test_authoritative_recovery_retries_empty_fresh_public_pass(
     )
     assert client.calls == 2
     assert "retrying the pinned source" in capsys.readouterr().out
+
+
+def test_authoritative_recovery_retries_zero_insert_with_incomplete_manifest(
+    monkeypatch, tmp_path, capsys
+):
+    graph = "owner/public-vm"
+
+    class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self):
+            self.calls = 0
+
+        def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
+            self.calls += 1
+            previous, current, inserted = (
+                (0, 500, 0) if self.calls == 1 else (500, 1_000, 250)
+            )
+            with (tmp_path / "daemon.log").open("a", encoding="utf-8") as handle:
+                handle.write(
+                    f'Rootless durable progress for "{graph}": '
+                    f'5 complete graph(s), safe offset {previous}->{current} '
+                    'of 1000 (raw 1000)\n'
+                )
+            return {
+                "ok": True,
+                "includeDurable": True,
+                "includeSharedMemory": False,
+                "peersAttempted": 1,
+                "totalDurableInsertedTriples": inserted,
+                "results": [{"peerId": peer_id}],
+            }
+
+        def threat_count(self, _cg_id):
+            return 100
+
+    client = FakeClient()
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
+
+    assert cli_mod._catchup_authoritative_vm(
+        client,
+        graph,
+        "publisher",
+        cli_mod.time.monotonic() + 60,
+    )
+    assert client.calls == 2
+    assert "snapshot remains incomplete (500/1,000)" in capsys.readouterr().out
 
 
 def test_authoritative_recovery_bounds_empty_fresh_public_passes(

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -1064,6 +1064,101 @@ def test_authoritative_recovery_retries_zero_insert_with_incomplete_manifest(
     assert "snapshot remains incomplete (500/1,000)" in capsys.readouterr().out
 
 
+def test_authoritative_recovery_bounds_unchanged_incomplete_manifest(
+    monkeypatch, tmp_path, capsys
+):
+    graph = "owner/public-vm"
+
+    class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self):
+            self.calls = 0
+
+        def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
+            self.calls += 1
+            with (tmp_path / "daemon.log").open("a", encoding="utf-8") as handle:
+                handle.write(
+                    f'Rootless durable progress for "{graph}": '
+                    "5 complete graph(s), safe offset 500->500 "
+                    "of 1000 (raw 1000)\n"
+                )
+            return {
+                "ok": True,
+                "includeDurable": True,
+                "includeSharedMemory": False,
+                "peersAttempted": 1,
+                "totalDurableInsertedTriples": 0,
+                "results": [{"peerId": peer_id}],
+            }
+
+    client = FakeClient()
+    states = []
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        cli_mod.sync_state,
+        "write",
+        lambda status, **details: states.append((status, details)) or details,
+    )
+
+    assert not cli_mod._catchup_authoritative_vm(
+        client,
+        graph,
+        "publisher",
+        cli_mod.time.monotonic() + 60,
+    )
+    assert client.calls == cli_mod._MAX_EMPTY_PUBLIC_PASSES
+    assert any(
+        status == "failed" and details.get("phase") == "stalled-verifiable-memory"
+        for status, details in states
+    )
+    assert "made no durable progress after 3 pinned passes" in capsys.readouterr().out
+
+
+def test_authoritative_recovery_allows_advancing_zero_insert_manifest(
+    monkeypatch, tmp_path
+):
+    graph = "owner/public-vm"
+    safe_offsets = iter((250, 500, 750, 1_000))
+
+    class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self):
+            self.calls = 0
+
+        def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
+            self.calls += 1
+            current = next(safe_offsets)
+            previous = current - 250
+            with (tmp_path / "daemon.log").open("a", encoding="utf-8") as handle:
+                handle.write(
+                    f'Rootless durable progress for "{graph}": '
+                    f"5 complete graph(s), safe offset {previous}->{current} "
+                    "of 1000 (raw 1000)\n"
+                )
+            return {
+                "ok": True,
+                "includeDurable": True,
+                "includeSharedMemory": False,
+                "peersAttempted": 1,
+                "totalDurableInsertedTriples": 250 if current == 1_000 else 0,
+                "results": [{"peerId": peer_id}],
+            }
+
+    client = FakeClient()
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
+
+    assert cli_mod._catchup_authoritative_vm(
+        client,
+        graph,
+        "publisher",
+        cli_mod.time.monotonic() + 60,
+    )
+    assert client.calls == 4
+
+
 def test_authoritative_recovery_bounds_empty_fresh_public_passes(
     monkeypatch, capsys
 ):
@@ -1194,6 +1289,46 @@ def test_authoritative_recovery_has_wall_clock_guard_and_heartbeats(
     output = capsys.readouterr().out
     assert "still active" in output
     assert any(status == "failed" for status, _details in states)
+
+
+def test_authoritative_recovery_does_not_overlap_active_watchdog_worker(monkeypatch):
+    release = threading.Event()
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = 0
+
+        def catchup_from_peer(self, _cg_id, _peer_id, *, budget_ms):
+            self.calls += 1
+            release.wait(1.0)
+            return {}
+
+    class EmptyQueue:
+        def put(self, _value):
+            return None
+
+        def get(self, *, timeout):
+            raise cli_mod.queue.Empty
+
+    clock = {"value": 0.0}
+
+    def monotonic():
+        clock["value"] += 11.0
+        return clock["value"]
+
+    client = FakeClient()
+    monkeypatch.setattr(cli_mod.queue, "Queue", lambda **_kwargs: EmptyQueue())
+    monkeypatch.setattr(cli_mod.time, "monotonic", monotonic)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
+
+    try:
+        assert not cli_mod._catchup_authoritative_vm(
+            client, "owner/public", "curator", 45.0
+        )
+        assert client.calls == 1
+    finally:
+        release.set()
 
 
 def test_blackbox_sync_ctrl_c_records_cancellation_and_returns_130(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- keep the Blackbox HTTP client and CLI watchdog alive while DKG verifies and atomically materializes a bounded durable batch
- use 60-second follow-up fetch windows so settlement finishes before DKG's responder-session TTL
- retry a zero-insert pass when the durable manifest still proves the snapshot is incomplete
- treat transient dial failures as pending peer discovery during fresh-node startup

## Root cause

Blackbox treated the DKG per-peer durable fetch budget as the lifetime of the entire synchronous request. The DKG route can spend substantially longer after fetching while it verifies exact graph assets against chain state and writes them atomically. Blackbox therefore abandoned valid in-flight work, then sometimes interpreted a later zero-insert response as completion even though the durable manifest remained incomplete.

Large follow-up fetch windows also produced settlement batches that could outlive DKG's ten-minute responder session and force the next pass back to offset zero.

## Impact

Fresh installations can complete large curator-pinned VM snapshots instead of stalling after a partial ruleset or looping on a stale/incomplete checkpoint. The change does not bypass graph or chain verification.

## Validation

- `scripts/run_tests.sh tests/plugins/test_blackbox_dkg_client.py tests/plugins/test_blackbox_plugin.py`
- 74 tests passed
- live recovery advanced monotonically to `5,337,721 / 5,337,721` verified triples and exposed 460,000 curated VM threats
- transient Base RPC and peer-dial failures were observed retrying without resetting the committed checkpoint
