### PR TITLE
fix(blackbox): page rules by verified VM partitions

### DIFF
--- a/plugins/blackbox/dashboard/server.py
+++ b/plugins/blackbox/dashboard/server.py
@@ -152,7 +152,8 @@ def _graph_source_count(rs: Any, source: str) -> int:
 def _graph_entries(rs: Any, source: str) -> List[Dict[str, Any]]:
     getter = getattr(rs, "graph_entries", None)
     if callable(getter):
-        return list(getter(source) or [])
+        entries = getter(source) or []
+        return entries if isinstance(entries, list) else list(entries)
     return [
         {
             "identifier": rule.get("identifier"),

--- a/plugins/blackbox/dkg_client.py
+++ b/plugins/blackbox/dkg_client.py
@@ -517,9 +517,10 @@ class DkgClient:
         self,
         sparql: str,
         cg_id: str,
-        view: str = constants.VIEW_VERIFIABLE_MEMORY,
+        view: Optional[str] = constants.VIEW_VERIFIABLE_MEMORY,
         on_error: Any = None,
         agent_address: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
         """Run a SPARQL SELECT and return normalized bindings.
 
@@ -529,7 +530,9 @@ class DkgClient:
         read paths fail open. A caller that must tell a genuine *empty* result
         (``[]``) apart from a *failure* passes a unique sentinel.
         """
-        payload = {"sparql": sparql, "contextGraphId": cg_id, "view": view}
+        payload = {"sparql": sparql, "contextGraphId": cg_id}
+        if view:
+            payload["view"] = view
         if agent_address:
             payload["agentAddress"] = agent_address
         try:
@@ -537,7 +540,7 @@ class DkgClient:
                 "POST",
                 "/api/query",
                 payload,
-                timeout=_QUERY_TIMEOUT,
+                timeout=timeout or _QUERY_TIMEOUT,
             )
         except DkgError as exc:
             logger.debug("blackbox: query failed: %s", exc)

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -21,7 +21,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from . import constants, quads
 from .config import BlackboxConfig, load_blackbox_config
@@ -64,16 +64,10 @@ def _defender_page_sparql(
     properties: str,
     limit: int,
     after: str,
+    graph_uri: str = "",
 ) -> str:
     cursor_filter = _threat_cursor_filter(after)
-    return f"""{_DEFENDER_PREFIXES}
-SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
-       ?pattern ?toolName ?argShape ?packageName ?packageVersion
-       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
-       ?skillVersion ?dangerShape ?kind ?iocValue ?targetSubject
-       ?correctionAction
-WHERE {{
-    {{
+    body = f"""    {{
         SELECT ?threat WHERE {{
             ?threat a defender:{signal_type} .
             {cursor_filter}
@@ -82,13 +76,23 @@ WHERE {{
         LIMIT {int(limit)}
     }}
     BIND(defender:{signal_type} AS ?rdfType)
-{properties}
+{properties}"""
+    if graph_uri:
+        body = f"  GRAPH <{graph_uri}> {{\n{body}\n  }}"
+    return f"""{_DEFENDER_PREFIXES}
+SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
+       ?pattern ?toolName ?argShape ?packageName ?packageVersion
+       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
+       ?skillVersion ?dangerShape ?kind ?iocValue ?targetSubject
+       ?correctionAction
+WHERE {{
+{body}
 }}
 ORDER BY STR(?threat)
 """
 
 
-def _threats_sparql(limit: int, after: str = "") -> str:
+def _threats_sparql(limit: int, after: str = "", graph_uri: str = "") -> str:
     return _defender_page_sparql(
         "DependencySignal",
         """    OPTIONAL { ?threat dp:kind ?kind . }
@@ -101,12 +105,17 @@ def _threats_sparql(limit: int, after: str = "") -> str:
     OPTIONAL { ?threat dp:advisoryId ?advisoryId . }""",
         limit,
         after,
+        graph_uri,
     )
 
 
-def _defender_threats_sparql(limit: int, after: str = "") -> tuple:
+def _defender_threats_sparql(
+    limit: int,
+    after: str = "",
+    graph_uri: str = "",
+) -> tuple:
     return (
-        _threats_sparql(limit, after),
+        _threats_sparql(limit, after, graph_uri),
         _defender_page_sparql(
             "InjectionSignal",
             """    OPTIONAL { ?threat dp:kind ?kind . }
@@ -116,6 +125,7 @@ def _defender_threats_sparql(limit: int, after: str = "") -> tuple:
     OPTIONAL { ?threat dp:pattern ?pattern . }""",
             limit,
             after,
+            graph_uri,
         ),
         _defender_page_sparql(
             "SkillSignal",
@@ -125,6 +135,7 @@ def _defender_threats_sparql(limit: int, after: str = "") -> tuple:
     OPTIONAL { ?threat schema:description ?description . }""",
             limit,
             after,
+            graph_uri,
         ),
         _defender_page_sparql(
             "IocSignal",
@@ -136,6 +147,7 @@ def _defender_threats_sparql(limit: int, after: str = "") -> tuple:
     OPTIONAL { ?threat dp:value ?iocValue . }""",
             limit,
             after,
+            graph_uri,
         ),
         _defender_page_sparql(
             "CorrectionSignal",
@@ -143,17 +155,18 @@ def _defender_threats_sparql(limit: int, after: str = "") -> tuple:
     OPTIONAL { ?threat dp:action ?correctionAction . }""",
             limit,
             after,
+            graph_uri,
         ),
     )
 
 
-def _legacy_threats_sparql(limit: int, after: str = "") -> str:
+def _legacy_threats_sparql(
+    limit: int,
+    after: str = "",
+    graph_uri: str = "",
+) -> str:
     cursor_filter = _threat_cursor_filter(after)
-    return f"""PREFIX g: <http://umanitek.ai/ontology/guardian/>
-PREFIX schema: <http://schema.org/>
-SELECT DISTINCT {_SELECT_COLUMNS}
-WHERE {{
-  {{
+    body = f"""  {{
     SELECT ?threat WHERE {{
       ?threat g:identifier ?cursorIdentifier .
       {cursor_filter}
@@ -178,7 +191,14 @@ WHERE {{
   OPTIONAL {{ ?threat g:category ?category . }}
   OPTIONAL {{ ?threat g:skillName ?skillName . }}
   OPTIONAL {{ ?threat g:skillVersion ?skillVersion . }}
-  OPTIONAL {{ ?threat g:dangerShape ?dangerShape . }}
+  OPTIONAL {{ ?threat g:dangerShape ?dangerShape . }}"""
+    if graph_uri:
+        body = f"  GRAPH <{graph_uri}> {{\n{body}\n  }}"
+    return f"""PREFIX g: <http://umanitek.ai/ontology/guardian/>
+PREFIX schema: <http://schema.org/>
+SELECT DISTINCT {_SELECT_COLUMNS}
+WHERE {{
+{body}
 }}
 ORDER BY STR(?threat)
 """
@@ -197,10 +217,10 @@ def _verified_partitions_sparql(cg_id: str) -> str:
         return ""
     vm_prefix = f"{data_graph}/_verifiable_memory/"
     return f"""PREFIX dkg: <http://dkg.io/ontology/>
-SELECT DISTINCT ?assertionGraph WHERE {{
+SELECT DISTINCT ?assertionGraph ?status WHERE {{
   GRAPH <{data_graph}/_meta> {{
-    ?ka dkg:assertionGraph ?assertionGraph ;
-        dkg:status "confirmed" .
+    ?ka dkg:assertionGraph ?assertionGraph .
+    OPTIONAL {{ ?ka dkg:status ?status . }}
   }}
   FILTER(STRSTARTS(STR(?assertionGraph), {json.dumps(vm_prefix)}))
 }}
@@ -833,19 +853,29 @@ def _fetch_tier(
 
         data_graph = _context_graph_data_uri(cg_id)
         vm_prefix = f"{data_graph}/_verifiable_memory/"
-        partitions = sorted({
-            graph
+        partition_metadata = [
+            (graph, extract_binding(row.get("status")))
             for row in metadata
             if (graph := extract_binding(row.get("assertionGraph"))).startswith(vm_prefix)
             and graph != vm_prefix
             and not any(char in graph for char in _FORBIDDEN_IRI_CHARS)
-        })
+        ]
+        partition_graphs = {graph for graph, _status in partition_metadata}
+        partitions = sorted(
+            {graph for graph, status in partition_metadata if status == "confirmed"}
+        )
+        # A broad VM query would union tentative assertion graphs and promote
+        # them to public rules. Preserve the last-good tier until every graph
+        # selected here is explicitly confirmed.
+        if partition_graphs and not partitions:
+            return None
+
+        partition_rows: List[Dict[str, Any]] = []
         if partitions:
-            rows: List[Dict[str, Any]] = []
             for start in range(0, len(partitions), _VM_PARTITION_BATCH_SIZE):
-                batch = partitions[start:start + _VM_PARTITION_BATCH_SIZE]
+                batch = partitions[start : start + _VM_PARTITION_BATCH_SIZE]
                 offset = 0
-                while len(rows) < _MAX_ROWS:
+                while len(partition_rows) < _MAX_ROWS:
                     page = client.query(
                         _partition_threats_sparql(batch, offset=offset),
                         cg_id,
@@ -855,25 +885,49 @@ def _fetch_tier(
                     )
                     if page is _QUERY_ERROR:
                         return None
-                    rows.extend(page)
+                    partition_rows.extend(page)
                     if len(page) < _VM_PARTITION_QUERY_LIMIT:
                         break
                     offset += _VM_PARTITION_QUERY_LIMIT
-            if len(rows) >= _MAX_ROWS:
+            if len(partition_rows) >= _MAX_ROWS:
                 return None
-            return rows
 
-        # Older root-only VM layouts do not have confirmed assertionGraph
-        # metadata. Keep the scoped pager as a compatibility fallback.
+        root_rows = _fetch_paged_lanes(
+            client,
+            cg_id,
+            lambda limit, after: (
+                _legacy_threats_sparql(limit, after, data_graph),
+                *_defender_threats_sparql(limit, after, data_graph),
+            ),
+            view=None,
+        )
+        if root_rows is None:
+            return None
+        if len(partition_rows) + len(root_rows) >= _MAX_ROWS:
+            return None
+        return _dedupe_threat_rows([*partition_rows, *root_rows])
 
-    rows: List[Dict[str, Any]] = []
-
-    def query_lanes(limit: int, after: str) -> tuple:
-        return (
+    return _fetch_paged_lanes(
+        client,
+        cg_id,
+        lambda limit, after: (
             _legacy_threats_sparql(limit, after),
             *_defender_threats_sparql(limit, after),
-        )
+        ),
+        view=view,
+        agent_address=agent_address,
+    )
 
+
+def _fetch_paged_lanes(
+    client: DkgClient,
+    cg_id: str,
+    query_lanes: Callable[[int, str], tuple],
+    *,
+    view: Optional[str],
+    agent_address: Optional[str] = None,
+) -> Optional[List[Dict[str, Any]]]:
+    rows: List[Dict[str, Any]] = []
     lane_count = len(query_lanes(1, ""))
     for lane_index in range(lane_count):
         after = ""
@@ -906,6 +960,20 @@ def _fetch_tier(
                 break
             after = next_cursor
     return rows
+
+
+def _dedupe_threat_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Prefer confirmed partition rows when a migrated root repeats a threat."""
+    result: List[Dict[str, Any]] = []
+    seen: set = set()
+    for row in rows:
+        threat = extract_binding(row.get("threat"))
+        if threat and threat in seen:
+            continue
+        if threat:
+            seen.add(threat)
+        result.append(row)
+    return result
 
 
 _EMPTY_RULESET_RETRY_S = 30.0

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -35,10 +35,132 @@ _SELECT_COLUMNS = """?threat ?rdfType ?identifier ?severity ?name ?description
        ?skillVersion ?dangerShape ?kind ?iocValue ?targetSubject
        ?correctionAction"""
 
-_LEGACY_THREATS_SELECT = f"""PREFIX g: <http://umanitek.ai/ontology/guardian/>
+_DEFENDER_PREFIXES = """PREFIX defender: <urn:defender:>
+PREFIX dp: <urn:defender:p:>
+PREFIX schema: <http://schema.org/>
+"""
+
+# Rows fetched per page when syncing a tier. One SPARQL round-trip each.
+_PAGE_SIZE = 5000
+# Safety ceiling so a misbehaving node can never spin the pager forever.
+_MAX_ROWS = 1_000_000
+# Public VM snapshots are stored in bounded, confirmed named graphs. Querying
+# five partitions at a time keeps Blazegraph responses comfortably below the
+# client timeout while avoiding the expensive all-VM deduplication rewrite.
+_VM_PARTITION_BATCH_SIZE = 5
+_VM_PARTITION_QUERY_LIMIT = 50_000
+_VM_PARTITION_QUERY_TIMEOUT = 120.0
+_FORBIDDEN_IRI_CHARS = frozenset('<>"{}|^`\\\r\n\t')
+
+
+def _threat_cursor_filter(after: str) -> str:
+    if not after:
+        return ""
+    return f"FILTER(STR(?threat) > {json.dumps(after, ensure_ascii=True)})"
+
+
+def _defender_page_sparql(
+    signal_type: str,
+    properties: str,
+    limit: int,
+    after: str,
+) -> str:
+    cursor_filter = _threat_cursor_filter(after)
+    return f"""{_DEFENDER_PREFIXES}
+SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
+       ?pattern ?toolName ?argShape ?packageName ?packageVersion
+       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
+       ?skillVersion ?dangerShape ?kind ?iocValue ?targetSubject
+       ?correctionAction
+WHERE {{
+    {{
+        SELECT ?threat WHERE {{
+            ?threat a defender:{signal_type} .
+            {cursor_filter}
+        }}
+        ORDER BY STR(?threat)
+        LIMIT {int(limit)}
+    }}
+    BIND(defender:{signal_type} AS ?rdfType)
+{properties}
+}}
+ORDER BY STR(?threat)
+"""
+
+
+def _threats_sparql(limit: int, after: str = "") -> str:
+    return _defender_page_sparql(
+        "DependencySignal",
+        """    OPTIONAL { ?threat dp:kind ?kind . }
+    OPTIONAL { ?threat dp:severity ?severity . }
+    OPTIONAL { ?threat schema:name ?name . }
+    OPTIONAL { ?threat schema:description ?description . }
+    OPTIONAL { ?threat dp:package ?packageName . }
+    OPTIONAL { ?threat dp:version ?packageVersion . }
+    OPTIONAL { ?threat dp:ecosystem ?packageEcosystem . }
+    OPTIONAL { ?threat dp:advisoryId ?advisoryId . }""",
+        limit,
+        after,
+    )
+
+
+def _defender_threats_sparql(limit: int, after: str = "") -> tuple:
+    return (
+        _threats_sparql(limit, after),
+        _defender_page_sparql(
+            "InjectionSignal",
+            """    OPTIONAL { ?threat dp:kind ?kind . }
+    OPTIONAL { ?threat dp:severity ?severity . }
+    OPTIONAL { ?threat schema:name ?name . }
+    OPTIONAL { ?threat schema:description ?description . }
+    OPTIONAL { ?threat dp:pattern ?pattern . }""",
+            limit,
+            after,
+        ),
+        _defender_page_sparql(
+            "SkillSignal",
+            """    OPTIONAL { ?threat dp:kind ?kind . }
+    OPTIONAL { ?threat dp:severity ?severity . }
+    OPTIONAL { ?threat schema:name ?name . }
+    OPTIONAL { ?threat schema:description ?description . }""",
+            limit,
+            after,
+        ),
+        _defender_page_sparql(
+            "IocSignal",
+            """    OPTIONAL { ?threat dp:kind ?kind . }
+    OPTIONAL { ?threat dp:severity ?severity . }
+    OPTIONAL { ?threat schema:name ?name . }
+    OPTIONAL { ?threat schema:description ?description . }
+    OPTIONAL { ?threat dp:iocType ?category . }
+    OPTIONAL { ?threat dp:value ?iocValue . }""",
+            limit,
+            after,
+        ),
+        _defender_page_sparql(
+            "CorrectionSignal",
+            """    OPTIONAL { ?threat dp:targetSubject ?targetSubject . }
+    OPTIONAL { ?threat dp:action ?correctionAction . }""",
+            limit,
+            after,
+        ),
+    )
+
+
+def _legacy_threats_sparql(limit: int, after: str = "") -> str:
+    cursor_filter = _threat_cursor_filter(after)
+    return f"""PREFIX g: <http://umanitek.ai/ontology/guardian/>
 PREFIX schema: <http://schema.org/>
 SELECT DISTINCT {_SELECT_COLUMNS}
 WHERE {{
+  {{
+    SELECT ?threat WHERE {{
+      ?threat g:identifier ?cursorIdentifier .
+      {cursor_filter}
+    }}
+    ORDER BY STR(?threat)
+    LIMIT {int(limit)}
+  }}
   ?threat g:identifier ?identifier .
   OPTIONAL {{ ?threat a ?rdfType . }}
   OPTIONAL {{ ?threat g:kind ?kind . }}
@@ -58,120 +180,89 @@ WHERE {{
   OPTIONAL {{ ?threat g:skillVersion ?skillVersion . }}
   OPTIONAL {{ ?threat g:dangerShape ?dangerShape . }}
 }}
-ORDER BY ?threat
+ORDER BY STR(?threat)
 """
 
-_DEFENDER_PREFIXES = """PREFIX defender: <urn:defender:>
-PREFIX dp: <urn:defender:p:>
-PREFIX schema: <http://schema.org/>
-"""
 
-_DEFENDER_DEPENDENCY_SELECT = f"""{_DEFENDER_PREFIXES}
-SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
-       ?pattern ?toolName ?argShape ?packageName ?packageVersion
-       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
-       ?skillVersion ?dangerShape ?kind ?iocValue
-WHERE {{
-    ?threat a defender:DependencySignal .
-    BIND(defender:DependencySignal AS ?rdfType)
-    OPTIONAL {{ ?threat dp:kind ?kind . }}
-    OPTIONAL {{ ?threat dp:severity ?severity . }}
-    OPTIONAL {{ ?threat schema:name ?name . }}
-    OPTIONAL {{ ?threat schema:description ?description . }}
-    OPTIONAL {{ ?threat dp:package ?packageName . }}
-    OPTIONAL {{ ?threat dp:version ?packageVersion . }}
-    OPTIONAL {{ ?threat dp:ecosystem ?packageEcosystem . }}
-    OPTIONAL {{ ?threat dp:advisoryId ?advisoryId . }}
+def _context_graph_data_uri(cg_id: str) -> str:
+    value = str(cg_id or "").strip()
+    if not value or any(char in value for char in _FORBIDDEN_IRI_CHARS):
+        return ""
+    return f"did:dkg:context-graph:{value}"
+
+
+def _verified_partitions_sparql(cg_id: str) -> str:
+    data_graph = _context_graph_data_uri(cg_id)
+    if not data_graph:
+        return ""
+    vm_prefix = f"{data_graph}/_verifiable_memory/"
+    return f"""PREFIX dkg: <http://dkg.io/ontology/>
+SELECT DISTINCT ?assertionGraph WHERE {{
+  GRAPH <{data_graph}/_meta> {{
+    ?ka dkg:assertionGraph ?assertionGraph ;
+        dkg:status "confirmed" .
+  }}
+  FILTER(STRSTARTS(STR(?assertionGraph), {json.dumps(vm_prefix)}))
 }}
-ORDER BY ?threat
+ORDER BY ?assertionGraph
 """
 
-_DEFENDER_INJECTION_SELECT = f"""{_DEFENDER_PREFIXES}
-SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
-       ?pattern ?toolName ?argShape ?packageName ?packageVersion
-       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
-       ?skillVersion ?dangerShape ?kind ?iocValue
+
+def _partition_threats_sparql(
+    graph_uris: List[str],
+    *,
+    limit: int = _VM_PARTITION_QUERY_LIMIT,
+    offset: int = 0,
+) -> str:
+    values = " ".join(f"<{uri}>" for uri in graph_uris)
+    return f"""{_DEFENDER_PREFIXES}PREFIX g: <http://umanitek.ai/ontology/guardian/>
+SELECT DISTINCT ?sourceGraph {_SELECT_COLUMNS}
 WHERE {{
-    ?threat a defender:InjectionSignal .
-    BIND(defender:InjectionSignal AS ?rdfType)
+  VALUES ?sourceGraph {{ {values} }}
+  GRAPH ?sourceGraph {{
+    {{
+      ?threat a ?rdfType .
+      VALUES ?rdfType {{
+        defender:DependencySignal defender:InjectionSignal
+        defender:SkillSignal defender:IocSignal defender:CorrectionSignal
+      }}
+    }} UNION {{
+      ?threat g:identifier ?identifier .
+      OPTIONAL {{ ?threat a ?rdfType . }}
+    }}
     OPTIONAL {{ ?threat dp:kind ?kind . }}
+    OPTIONAL {{ ?threat g:kind ?kind . }}
     OPTIONAL {{ ?threat dp:severity ?severity . }}
+    OPTIONAL {{ ?threat g:severity ?severity . }}
     OPTIONAL {{ ?threat schema:name ?name . }}
     OPTIONAL {{ ?threat schema:description ?description . }}
     OPTIONAL {{ ?threat dp:pattern ?pattern . }}
-}}
-ORDER BY ?threat
-"""
-
-_DEFENDER_SKILL_SELECT = f"""{_DEFENDER_PREFIXES}
-SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
-       ?pattern ?toolName ?argShape ?packageName ?packageVersion
-       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
-       ?skillVersion ?dangerShape ?kind ?iocValue
-WHERE {{
-    ?threat a defender:SkillSignal .
-    BIND(defender:SkillSignal AS ?rdfType)
-    OPTIONAL {{ ?threat dp:kind ?kind . }}
-    OPTIONAL {{ ?threat dp:severity ?severity . }}
-    OPTIONAL {{ ?threat schema:name ?name . }}
-    OPTIONAL {{ ?threat schema:description ?description . }}
-}}
-ORDER BY ?threat
-"""
-
-_DEFENDER_IOC_SELECT = f"""{_DEFENDER_PREFIXES}
-SELECT DISTINCT ?threat ?rdfType ?identifier ?severity ?name ?description
-       ?pattern ?toolName ?argShape ?packageName ?packageVersion
-       ?packageEcosystem ?advisoryId ?curated ?category ?skillName
-       ?skillVersion ?dangerShape ?kind ?iocValue
-WHERE {{
-    ?threat a defender:IocSignal .
-    BIND(defender:IocSignal AS ?rdfType)
-    OPTIONAL {{ ?threat dp:kind ?kind . }}
-    OPTIONAL {{ ?threat dp:severity ?severity . }}
-    OPTIONAL {{ ?threat schema:name ?name . }}
-    OPTIONAL {{ ?threat schema:description ?description . }}
+    OPTIONAL {{ ?threat g:pattern ?pattern . }}
+    OPTIONAL {{ ?threat g:toolName ?toolName . }}
+    OPTIONAL {{ ?threat g:argShape ?argShape . }}
+    OPTIONAL {{ ?threat dp:package ?packageName . }}
+    OPTIONAL {{ ?threat g:packageName ?packageName . }}
+    OPTIONAL {{ ?threat dp:version ?packageVersion . }}
+    OPTIONAL {{ ?threat g:packageVersion ?packageVersion . }}
+    OPTIONAL {{ ?threat dp:ecosystem ?packageEcosystem . }}
+    OPTIONAL {{ ?threat g:packageEcosystem ?packageEcosystem . }}
+    OPTIONAL {{ ?threat dp:advisoryId ?advisoryId . }}
+    OPTIONAL {{ ?threat schema:identifier ?advisoryId . }}
+    OPTIONAL {{ ?threat g:curated ?curated . }}
     OPTIONAL {{ ?threat dp:iocType ?category . }}
+    OPTIONAL {{ ?threat g:category ?category . }}
+    OPTIONAL {{ ?threat g:skillName ?skillName . }}
+    OPTIONAL {{ ?threat g:skillVersion ?skillVersion . }}
+    OPTIONAL {{ ?threat g:dangerShape ?dangerShape . }}
     OPTIONAL {{ ?threat dp:value ?iocValue . }}
+    OPTIONAL {{ ?threat dp:targetSubject ?targetSubject . }}
+    OPTIONAL {{ ?threat dp:action ?correctionAction . }}
+  }}
 }}
-ORDER BY ?threat
+ORDER BY ?sourceGraph ?threat
+LIMIT {int(limit)}
+OFFSET {int(offset)}
 """
-
-_DEFENDER_CORRECTION_SELECT = f"""{_DEFENDER_PREFIXES}
-SELECT DISTINCT {_SELECT_COLUMNS}
-WHERE {{
-    ?threat a defender:CorrectionSignal .
-    BIND(defender:CorrectionSignal AS ?rdfType)
-    ?threat dp:targetSubject ?targetSubject .
-    ?threat dp:action ?correctionAction .
-}}
-ORDER BY ?threat
-"""
-
-# Rows fetched per page when syncing a tier. One SPARQL round-trip each.
-_PAGE_SIZE = 5000
-# Safety ceiling so a misbehaving node can never spin the pager forever.
-_MAX_ROWS = 1_000_000
-
-
-def _threats_sparql(limit: int, offset: int) -> str:
-    return f"{_DEFENDER_DEPENDENCY_SELECT}LIMIT {int(limit)} OFFSET {int(offset)}"
-
-
-def _defender_threats_sparql(limit: int, offset: int) -> tuple:
-    limit = int(limit)
-    offset = int(offset)
-    return (
-        f"{_DEFENDER_DEPENDENCY_SELECT}LIMIT {limit} OFFSET {offset}",
-        f"{_DEFENDER_INJECTION_SELECT}LIMIT {limit} OFFSET {offset}",
-        f"{_DEFENDER_SKILL_SELECT}LIMIT {limit} OFFSET {offset}",
-        f"{_DEFENDER_IOC_SELECT}LIMIT {limit} OFFSET {offset}",
-        f"{_DEFENDER_CORRECTION_SELECT}LIMIT {limit} OFFSET {offset}",
-    )
-
-
-def _legacy_threats_sparql(limit: int, offset: int) -> str:
-    return f"{_LEGACY_THREATS_SELECT}LIMIT {int(limit)} OFFSET {int(offset)}"
 
 
 def community_report_count(client: DkgClient, cfg: BlackboxConfig) -> int:
@@ -270,6 +361,11 @@ class Ruleset:
     ioc: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     graph_threats: List[Dict[str, Any]] = field(default_factory=list)
     synced_at: float = 0.0
+    _graph_entries_cache: Dict[str, List[Dict[str, Any]]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
 
     def counts(self) -> Dict[str, int]:
         return {
@@ -303,6 +399,9 @@ class Ruleset:
         return sum(1 for _cat, r in self.iter_rules() if r.get("source") == source)
 
     def graph_entries(self, source: str) -> List[Dict[str, Any]]:
+        cached = self._graph_entries_cache.get(source)
+        if cached is not None:
+            return cached
         entries = [item for item in self.graph_threats if item.get("source") == source]
         seen = {item.get("identifier") for item in entries}
         for category, rule in self.iter_rules():
@@ -318,6 +417,7 @@ class Ruleset:
                 "subject": rule.get("subject") or "",
                 "source": source,
             })
+        self._graph_entries_cache[source] = entries
         return entries
 
     def graph_count(self, source: str) -> int:
@@ -718,27 +818,93 @@ def _fetch_tier(
     the caller can preserve a tier's last-good rules through a transient failure
     instead of wiping them.
     """
+    if view == constants.VIEW_VERIFIABLE_MEMORY:
+        partition_query = _verified_partitions_sparql(cg_id)
+        if not partition_query:
+            return None
+        metadata = client.query(
+            partition_query,
+            cg_id,
+            view=None,
+            on_error=_QUERY_ERROR,
+        )
+        if metadata is _QUERY_ERROR:
+            return None
+
+        data_graph = _context_graph_data_uri(cg_id)
+        vm_prefix = f"{data_graph}/_verifiable_memory/"
+        partitions = sorted({
+            graph
+            for row in metadata
+            if (graph := extract_binding(row.get("assertionGraph"))).startswith(vm_prefix)
+            and graph != vm_prefix
+            and not any(char in graph for char in _FORBIDDEN_IRI_CHARS)
+        })
+        if partitions:
+            rows: List[Dict[str, Any]] = []
+            for start in range(0, len(partitions), _VM_PARTITION_BATCH_SIZE):
+                batch = partitions[start:start + _VM_PARTITION_BATCH_SIZE]
+                offset = 0
+                while len(rows) < _MAX_ROWS:
+                    page = client.query(
+                        _partition_threats_sparql(batch, offset=offset),
+                        cg_id,
+                        view=None,
+                        on_error=_QUERY_ERROR,
+                        timeout=_VM_PARTITION_QUERY_TIMEOUT,
+                    )
+                    if page is _QUERY_ERROR:
+                        return None
+                    rows.extend(page)
+                    if len(page) < _VM_PARTITION_QUERY_LIMIT:
+                        break
+                    offset += _VM_PARTITION_QUERY_LIMIT
+            if len(rows) >= _MAX_ROWS:
+                return None
+            return rows
+
+        # Older root-only VM layouts do not have confirmed assertionGraph
+        # metadata. Keep the scoped pager as a compatibility fallback.
+
     rows: List[Dict[str, Any]] = []
-    query_groups = (
-        lambda limit, offset: (_legacy_threats_sparql(limit, offset),),
-        _defender_threats_sparql,
-    )
-    for query_group in query_groups:
-        offset = 0
-        while offset < _MAX_ROWS:
+
+    def query_lanes(limit: int, after: str) -> tuple:
+        return (
+            _legacy_threats_sparql(limit, after),
+            *_defender_threats_sparql(limit, after),
+        )
+
+    lane_count = len(query_lanes(1, ""))
+    for lane_index in range(lane_count):
+        after = ""
+        fetched_subjects = 0
+        while fetched_subjects < _MAX_ROWS:
             kwargs: Dict[str, Any] = {"view": view, "on_error": _QUERY_ERROR}
             if agent_address:
                 kwargs["agent_address"] = agent_address
-            pages = []
-            for query in query_group(_PAGE_SIZE, offset):
-                page = client.query(query, cg_id, **kwargs)
-                if page is _QUERY_ERROR:
+            query = query_lanes(_PAGE_SIZE, after)[lane_index]
+            page = client.query(query, cg_id, **kwargs)
+            if page is _QUERY_ERROR:
+                return None
+            rows.extend(page)
+            page_subjects = list(
+                dict.fromkeys(
+                    subject
+                    for row in page
+                    if (subject := extract_binding(row.get("threat")))
+                )
+            )
+            if not page_subjects:
+                if page:
                     return None
-                pages.append(page)
-                rows.extend(page)
-            if all(len(page) < _PAGE_SIZE for page in pages):
                 break
-            offset += _PAGE_SIZE
+            next_cursor = page_subjects[-1]
+            if next_cursor <= after:
+                return None
+            fetched_subjects += len(page_subjects)
+            if len(page_subjects) < _PAGE_SIZE:
+                break
+            after = next_cursor
     return rows
 
 
@@ -844,6 +1010,7 @@ def _restore_tiers(rs: Ruleset, prior: Ruleset, tiers: List[str]) -> None:
             existing = target.get(key)
             if existing is None or (existing.get("source") == "community" and rule.get("source") == "public"):
                 target[key] = rule
+    rs._graph_entries_cache.clear()
 
 
 def _background_refresh(config: BlackboxConfig) -> None:

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -94,7 +94,8 @@ class _Pager:
             return [{
                 "assertionGraph": {
                     "value": f"{data_graph}/_verifiable_memory/partition/{i:04d}"
-                }
+                },
+                "status": {"value": "confirmed"},
             } for i in range(partition_count)]
         if "VALUES ?sourceGraph" not in sparql:
             return []

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -84,21 +84,60 @@ class _Pager:
 
     def __init__(self, n):
         self.n = n
+        self.queries = []
 
-    def query(self, sparql, cg_id, view=None, on_error=None):
-        if view != constants.VIEW_VERIFIABLE_MEMORY:
+    def query(self, sparql, cg_id, view=None, on_error=None, **kwargs):
+        self.queries.append((sparql, {"view": view, **kwargs}))
+        data_graph = f"did:dkg:context-graph:{cg_id}"
+        if "dkg:assertionGraph" in sparql:
+            partition_count = (self.n + 999) // 1000
+            return [{
+                "assertionGraph": {
+                    "value": f"{data_graph}/_verifiable_memory/partition/{i:04d}"
+                }
+            } for i in range(partition_count)]
+        if "VALUES ?sourceGraph" not in sparql:
             return []
         lim = int(re.search(r"LIMIT (\d+)", sparql).group(1))
         off = int(re.search(r"OFFSET (\d+)", sparql).group(1))
-        return [{"identifier": {"value": f"dep:npm:pkg{i}@1.0"}, "packageEcosystem": {"value": "npm"},
-                 "packageName": {"value": f"pkg{i}"}, "packageVersion": {"value": "1.0"},
-                 "severity": {"value": "critical"}} for i in range(off, min(off + lim, self.n))]
+        partitions = [
+            int(value)
+            for value in re.findall(r"/_verifiable_memory/partition/(\d{4})>", sparql)
+        ]
+        rows = []
+        for partition in partitions:
+            start = partition * 1000
+            end = min(start + 1000, self.n)
+            rows.extend({
+                "threat": {"value": f"urn:test:dependency:{i:08d}"},
+                "rdfType": {"value": "urn:defender:DependencySignal"},
+                "packageEcosystem": {"value": "npm"},
+                "packageName": {"value": f"pkg{i}"},
+                "packageVersion": {"value": "1.0"},
+                "severity": {"value": "critical"},
+            } for i in range(start, end))
+        return rows[off:off + lim]
 
 def test_ruleset_sync_is_uncapped(monkeypatch):
     monkeypatch.setattr(ruleset_mod, "_write_cache", lambda rs: None)
     monkeypatch.setattr(ruleset_mod, "_memory_cache", None)
-    rs = ruleset_mod.refresh(config_mod.BlackboxConfig(), _Pager(6500))
-    assert len(rs.dependency) == 6500  # far past the old LIMIT 2000
+    pager = _Pager(16_250)
+    rs = ruleset_mod.refresh(config_mod.BlackboxConfig(), pager)
+    assert len(rs.dependency) == 16_250
+    metadata_queries = [query for query, _kwargs in pager.queries if "dkg:assertionGraph" in query]
+    partition_queries = [
+        (query, kwargs)
+        for query, kwargs in pager.queries
+        if "VALUES ?sourceGraph" in query
+    ]
+    assert len(metadata_queries) == 1
+    assert len(partition_queries) == 4
+    assert all("OFFSET 0" in query for query, _kwargs in partition_queries)
+    assert all(kwargs["view"] is None for _query, kwargs in partition_queries)
+    assert all(
+        kwargs["timeout"] == ruleset_mod._VM_PARTITION_QUERY_TIMEOUT
+        for _query, kwargs in partition_queries
+    )
 
 
 def test_empty_initial_sync_retries_cache_without_network_orchestration(monkeypatch):

--- a/tests/plugins/test_blackbox_dkg_client.py
+++ b/tests/plugins/test_blackbox_dkg_client.py
@@ -305,6 +305,22 @@ def test_query_normalizes_bindings(monkeypatch):
     assert json.loads(cap["body"])["view"] == "verifiable-memory"
 
 
+def test_scoped_graph_query_can_omit_the_memory_view(monkeypatch):
+    cap = _capture(monkeypatch, '{"bindings": []}')
+    client = dkg_client.DkgClient(url="http://node", token="t")
+
+    client.query(
+        "SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }",
+        "cg",
+        view=None,
+    )
+
+    assert json.loads(cap["body"]) == {
+        "sparql": "SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }",
+        "contextGraphId": "cg",
+    }
+
+
 def test_threat_count_uses_one_verifiable_memory_query(monkeypatch):
     cap = _capture(
         monkeypatch,

--- a/tests/plugins/test_blackbox_tiers.py
+++ b/tests/plugins/test_blackbox_tiers.py
@@ -150,6 +150,76 @@ def test_root_only_graph_schemas_are_queried_separately_and_merged():
     assert len(rows) == 2
     assert len(queries) == 7
     assert all("UNION" not in query for query in queries[1:])
+    assert all("GRAPH <did:dkg:context-graph:cg>" in query for query in queries[1:])
+
+
+def test_tentative_vm_partitions_fail_closed_without_broad_view():
+    calls = []
+
+    class _Client:
+        def query(self, sparql, cg_id, **kwargs):
+            calls.append((sparql, kwargs))
+            if "dkg:assertionGraph" not in sparql:
+                raise AssertionError("tentative partitions must not be queried")
+            return [{
+                "assertionGraph": {
+                    "value": (
+                        "did:dkg:context-graph:cg/"
+                        "_verifiable_memory/partition/0000"
+                    )
+                },
+                "status": {"value": "tentative"},
+            }]
+
+    assert ruleset_mod._fetch_tier(_Client(), "cg", "verifiable-memory") is None
+    assert len(calls) == 1
+    assert calls[0][1]["view"] is None
+
+
+def test_mixed_vm_store_merges_root_and_confirmed_partitions_without_duplicates():
+    data_graph = "did:dkg:context-graph:cg"
+    root_only = "urn:defender:signal:root"
+    partition_only = "urn:defender:signal:partition"
+    duplicate = "urn:defender:signal:duplicate"
+    calls = []
+
+    class _Client:
+        def query(self, sparql, cg_id, **kwargs):
+            calls.append((sparql, kwargs))
+            if "dkg:assertionGraph" in sparql:
+                return [{
+                    "assertionGraph": {
+                        "value": f"{data_graph}/_verifiable_memory/partition/0000"
+                    },
+                    "status": {"value": "confirmed"},
+                }]
+            if "VALUES ?sourceGraph" in sparql:
+                return [
+                    {"threat": {"value": partition_only}},
+                    {"threat": {"value": duplicate}},
+                ]
+            if "defender:DependencySignal" in sparql:
+                return [
+                    {"threat": {"value": root_only}},
+                    {"threat": {"value": duplicate}},
+                ]
+            return []
+
+    rows = ruleset_mod._fetch_tier(_Client(), "cg", "verifiable-memory")
+
+    assert [ruleset_mod.extract_binding(row.get("threat")) for row in rows] == [
+        partition_only,
+        duplicate,
+        root_only,
+    ]
+    assert all(kwargs["view"] is None for _query, kwargs in calls)
+    root_queries = [
+        query
+        for query, _kwargs in calls
+        if "dkg:assertionGraph" not in query and "VALUES ?sourceGraph" not in query
+    ]
+    assert root_queries
+    assert all(f"GRAPH <{data_graph}>" in query for query in root_queries)
 
 
 def test_vm_correction_suppresses_exact_subject_from_detection_and_graph():

--- a/tests/plugins/test_blackbox_tiers.py
+++ b/tests/plugins/test_blackbox_tiers.py
@@ -113,21 +113,26 @@ def test_defender_entities_are_expanded_into_individual_rules():
     assert rs.counts()["skill"] == 32
     assert rs.source_count("public") == 1000
     assert rs.graph_count("public") == 1000
+    assert rs.graph_entries("public") is rs.graph_entries("public")
     assert len({rule["identifier"] for _category, rule in rs.iter_rules()}) == 1000
-    sparql = ruleset_mod._threats_sparql(1000, 0)
+    sparql = ruleset_mod._threats_sparql(1000)
     assert "defender:DependencySignal" in sparql
-    split_sparql = "\n".join(ruleset_mod._defender_threats_sparql(1000, 0))
+    split_sparql = "\n".join(ruleset_mod._defender_threats_sparql(1000))
     assert "defender:InjectionSignal" in split_sparql
     assert "defender:SkillSignal" in split_sparql
     assert "UNION" not in sparql
+    assert "OFFSET" not in split_sparql
+    assert "SELECT ?threat WHERE" in split_sparql
 
 
-def test_graph_schemas_are_queried_separately_and_merged():
+def test_root_only_graph_schemas_are_queried_separately_and_merged():
     queries = []
 
     class _Client:
         def query(self, sparql, cg_id, **kwargs):
             queries.append(sparql)
+            if "dkg:assertionGraph" in sparql:
+                return []
             if "defender:DependencySignal" in sparql:
                 return [{
                     "threat": {"value": "urn:defender:signal:1"},
@@ -143,8 +148,8 @@ def test_graph_schemas_are_queried_separately_and_merged():
     rows = ruleset_mod._fetch_tier(_Client(), "cg", "verifiable-memory")
 
     assert len(rows) == 2
-    assert len(queries) == 6
-    assert all("UNION" not in query for query in queries)
+    assert len(queries) == 7
+    assert all("UNION" not in query for query in queries[1:])
 
 
 def test_vm_correction_suppresses_exact_subject_from_detection_and_graph():

--- a/tests/plugins/test_blackbox_vm_only.py
+++ b/tests/plugins/test_blackbox_vm_only.py
@@ -22,19 +22,25 @@ OPENCLAW_DIR = Path(__file__).resolve().parents[2] / "integrations" / "openclaw"
 
 
 def test_refresh_queries_only_verifiable_memory(monkeypatch, tmp_path):
-    views = []
+    queries = []
 
     class Client:
-        def query(self, _query, _cg, **kwargs):
-            views.append(kwargs["view"])
+        def query(self, sparql, _cg, **kwargs):
+            queries.append((sparql, kwargs["view"]))
             return []
 
     monkeypatch.setattr(constants, "blackbox_home", lambda: tmp_path)
     monkeypatch.setattr(ruleset, "_memory_cache", None)
     ruleset.refresh(config.BlackboxConfig(), Client())
 
-    assert views
-    assert set(views) == {constants.VIEW_VERIFIABLE_MEMORY}
+    assert queries
+    metadata_query, metadata_view = queries[0]
+    assert metadata_view is None
+    assert "dkg:assertionGraph" in metadata_query
+    assert "/_meta>" in metadata_query
+    assert {view for _query, view in queries[1:]} == {
+        constants.VIEW_VERIFIABLE_MEMORY
+    }
 
 
 def test_cached_community_rules_are_discarded():

--- a/tests/plugins/test_blackbox_vm_only.py
+++ b/tests/plugins/test_blackbox_vm_only.py
@@ -31,16 +31,17 @@ def test_refresh_queries_only_verifiable_memory(monkeypatch, tmp_path):
 
     monkeypatch.setattr(constants, "blackbox_home", lambda: tmp_path)
     monkeypatch.setattr(ruleset, "_memory_cache", None)
-    ruleset.refresh(config.BlackboxConfig(), Client())
+    cfg = config.BlackboxConfig()
+    ruleset.refresh(cfg, Client())
 
     assert queries
     metadata_query, metadata_view = queries[0]
     assert metadata_view is None
     assert "dkg:assertionGraph" in metadata_query
     assert "/_meta>" in metadata_query
-    assert {view for _query, view in queries[1:]} == {
-        constants.VIEW_VERIFIABLE_MEMORY
-    }
+    data_graph = f"did:dkg:context-graph:{cfg.context_graph_id}"
+    assert {view for _query, view in queries[1:]} == {None}
+    assert all(f"GRAPH <{data_graph}>" in query for query, _view in queries[1:])
 
 
 def test_cached_community_rules_are_discarded():


### PR DESCRIPTION
## Summary

- paginate the verified threat corpus by confirmed VM partition instead of global `LIMIT/OFFSET` over the complete VM union
- fetch five exact partitions per bounded query with a background-specific timeout
- retain the root-only VM compatibility pager and fail-open cache semantics
- cache each ruleset generation's dashboard graph projection

## Problem

A completed DKG transfer of 460,000 verified public threats could leave the Blackbox ruleset and dashboard pinned to an older 15,000-threat cache.

### Observed behavior

- `authoritative-sync.json` reported `expected_public_entries=460000`, `public_entries=460000`, and `status=done`.
- `/api/graph-status` still reported `curated=15000`.
- `/api/graph?tier=public&limit=1` still reported `total=15000`.
- The dashboard could not page beyond those stale 15,000 cached rows.

### Expected behavior

- A successful ruleset refresh reads every confirmed public VM partition.
- A failed refresh preserves the complete last-good cache.
- `/api/graph-status` reaches the full verified threat count.
- `/api/graph` returns bounded pages while exposing the complete cached corpus.
- Repeated dashboard status polling does not rebuild the complete 460,000-entry projection.

## Root cause

The previous refresher paginated one logical VM union using global `ORDER BY ... LIMIT/OFFSET` queries. DKG scopes that query across hundreds of confirmed per-KA VM partitions and performs cross-partition deduplication. Later pages eventually exceeded Blackbox's 30-second query timeout.

The fail-open path correctly preserved the last-good cache, but that cache represented only the first 15,000 threats. Timed-out HTTP clients could also leave Blazegraph evaluating abandoned global queries, increasing pressure on later refresh attempts.

## Implementation

The DKG store already exposes a safe paging boundary: confirmed `dkg:assertionGraph` partitions in the Context Graph `_meta` graph. Querying five exact partitions at a time avoids the expensive all-VM deduplication plan and keeps each response bounded.

- discover only confirmed assertion graphs under the target Context Graph's VM namespace
- query five exact named graphs per batch with a dedicated 120-second background timeout
- reject malformed or out-of-scope graph IRIs before interpolating them into SPARQL
- preserve the legacy scoped pager when an older root-only VM layout has no partition metadata
- retain atomic, fail-open cache replacement semantics
- memoize each ruleset generation's dashboard graph projection

## Acceptance criteria

- [x] Regression coverage crosses the observed 15,000-row plateau.
- [x] Live validation returns 460,000 unique threat subjects.
- [x] Older root-only VM layouts retain compatibility.
- [x] Public VM content is read only from confirmed assertion partitions.
- [x] A failed partition query preserves the last-good cache.
- [x] Blackbox plugin and dashboard tests pass.

## Validation

- `scripts/run_tests.sh tests/plugins/test_blackbox_*.py tests/test_blackbox_dashboard_chat.py`
  - 20 files, 414 tests passed
- live 460-partition graph fetch
  - 460 confirmed VM partitions
  - 460,000 rows
  - 460,000 unique threat subjects
  - completed in 141.34 seconds without writing the production cache
- live patched cache and dashboard
  - `/api/graph-status`: `curated=460000`, `ruleset_total=460000`
  - `/api/graph?tier=public&limit=1&offset=459999`: final row returned with `total=460000`

## Related work

Companion sync-settlement PR: #7
Companion DKG retry PR: OriginTrail/dkg#1904
