### PR TITLE
Codex/fix pr6 review findings

### DIFF
--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -29,9 +29,9 @@ from .dkg_progress import read_durable_progress
 logger = logging.getLogger(__name__)
 
 _DKG_STEADY_SYNC_SETTINGS = {
-    "DKG_SYNC_ON_CONNECT_ENABLED": "0",
-    "DKG_SYNC_RECONCILER_ENABLED": "0",
-    "DKG_DURABLE_SYNC_ENABLED": "0",
+    "DKG_SYNC_ON_CONNECT_ENABLED": "1",
+    "DKG_SYNC_RECONCILER_ENABLED": "1",
+    "DKG_DURABLE_SYNC_ENABLED": "1",
     "DKG_SYNC_GLOBAL_MAX_INFLIGHT": "1",
     "DKG_SYNC_GLOBAL_QUEUE_LIMIT": "0",
 }
@@ -462,9 +462,9 @@ def _cmd_sync(args: argparse.Namespace) -> int:
     """Run a ruleset sync, translating an interactive cancellation cleanly."""
     try:
         cfg = load_blackbox_config()
-        if not _uses_managed_sync_window(cfg, args):
+        if not _uses_managed_dkg(cfg, args):
             return _cmd_sync_impl(args)
-        return _cmd_sync_in_managed_window(cfg, args)
+        return _cmd_sync_with_managed_dkg(cfg, args)
     except KeyboardInterrupt:
         try:
             current_transfer = sync_state.read()
@@ -491,7 +491,7 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         return 130
 
 
-def _uses_managed_sync_window(cfg: BlackboxConfig, args: argparse.Namespace) -> bool:
+def _uses_managed_dkg(cfg: BlackboxConfig, args: argparse.Namespace) -> bool:
     """Return whether this is a blocking sync for Blackbox's managed DKG."""
     return bool(
         getattr(args, "wait", False)
@@ -545,11 +545,10 @@ def _managed_sync_lock():
         handle.close()
 
 
-def _dkg_sync_environment(cfg: BlackboxConfig, *, durable: bool) -> Dict[str, str]:
+def _dkg_sync_environment(cfg: BlackboxConfig) -> Dict[str, str]:
     env = os.environ.copy()
     env.update(_DKG_STEADY_SYNC_SETTINGS)
     env["DKG_HOME"] = str(cfg.dkg_home)
-    env["DKG_DURABLE_SYNC_ENABLED"] = "1" if durable else "0"
     env.setdefault("DKG_CATCHUP_MAX_CONCURRENT_PEERS", "1")
     env.setdefault("DKG_STORE_QUEUE_WAIT_TIMEOUT_MS", "300000")
     env.setdefault("DKG_SYNC_TOTAL_TIMEOUT_MS", "1800000")
@@ -643,27 +642,32 @@ def _node_runtime_matches_dkg(executable: Path, cfg: BlackboxConfig) -> bool:
     return result.returncode == 0
 
 
-def _set_persisted_dkg_steady_state(cfg: BlackboxConfig) -> None:
-    """Keep the managed node's on-disk defaults in the stabilized state."""
+def _set_persisted_dkg_steady_state(cfg: BlackboxConfig) -> bool:
+    """Persist bounded native reconciliation and report whether it changed."""
     path = Path(cfg.dkg_home) / "config.json"
     data = json.loads(path.read_text(encoding="utf-8"))
+    original = json.dumps(data, sort_keys=True)
     data.update(
         {
-            "syncOnConnectEnabled": False,
-            "syncReconcilerEnabled": False,
-            "durableSyncEnabled": False,
+            "syncOnConnectEnabled": True,
+            "syncReconcilerEnabled": True,
+            "durableSyncEnabled": True,
             "syncGlobalMaxInflight": 1,
             "syncGlobalQueueLimit": 0,
+            "syncSharedMemoryOnConnect": False,
         }
     )
+    if original == json.dumps(data, sort_keys=True):
+        return False
     tmp = path.with_suffix(f".tmp-{os.getpid()}")
     tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     os.replace(tmp, path)
+    return True
 
 
-def _restart_managed_dkg(cfg: BlackboxConfig, *, durable: bool) -> None:
-    """Restart the managed node in a controlled sync or steady-state mode."""
-    env = _dkg_sync_environment(cfg, durable=durable)
+def _restart_managed_dkg(cfg: BlackboxConfig) -> None:
+    """Restart the managed node with bounded native reconciliation enabled."""
+    env = _dkg_sync_environment(cfg)
     command = str(cfg.dkg_bin)
     try:
         subprocess.run(
@@ -721,8 +725,8 @@ def _last_sync_counts() -> tuple[int, int]:
     return public, community
 
 
-def _cmd_sync_in_managed_window(cfg: BlackboxConfig, args: argparse.Namespace) -> int:
-    """Run one durable catch-up, restoring stabilized settings before completion."""
+def _cmd_sync_with_managed_dkg(cfg: BlackboxConfig, args: argparse.Namespace) -> int:
+    """Run one foreground catch-up while DKG owns ongoing reconciliation."""
     with _managed_sync_lock() as acquired:
         if not acquired:
             print("Blackbox sync is already running; no second transfer was queued.")
@@ -733,48 +737,25 @@ def _cmd_sync_in_managed_window(cfg: BlackboxConfig, args: argparse.Namespace) -
             "running",
             context_graph_id=cfg.context_graph_id,
             graph_peer_id=cfg.graph_peer_id,
-            phase="preparing-sync-window",
+            phase="preparing-managed-sync",
             public_entries=known_public,
             community_entries=known_community,
         )
         terminal_state: Dict[str, Any] = {}
         result = 2
         failure: Optional[BaseException] = None
-        restore_failure: Optional[Exception] = None
         try:
-            _set_persisted_dkg_steady_state(cfg)
-            _restart_managed_dkg(cfg, durable=True)
+            # Upgrade installs that previously disabled the native reconciler.
+            # Do not restart an already-correct node: preserving the pinned
+            # curator connection lets DKG resume the same manifest after this
+            # foreground command reaches its own deadline.
+            if _set_persisted_dkg_steady_state(cfg):
+                _restart_managed_dkg(cfg)
             result = _cmd_sync_impl(args)
             terminal_state = sync_state.read()
         except BaseException as exc:
             failure = exc
             terminal_state = sync_state.read()
-        finally:
-            details = _terminal_sync_details(terminal_state)
-            details.update(
-                context_graph_id=cfg.context_graph_id,
-                graph_peer_id=cfg.graph_peer_id,
-                phase="restoring-steady-state",
-            )
-            sync_state.write("running", **details)
-            try:
-                _set_persisted_dkg_steady_state(cfg)
-                _restart_managed_dkg(cfg, durable=False)
-                _set_persisted_dkg_steady_state(cfg)
-            except Exception as restore_exc:
-                restore_failure = restore_exc
-
-        if restore_failure is not None:
-            failed_details = _terminal_sync_details(terminal_state)
-            failed_details.update(
-                context_graph_id=cfg.context_graph_id,
-                graph_peer_id=cfg.graph_peer_id,
-                phase="restoring-steady-state",
-                error=f"DKG steady-state restore failed: {restore_failure}",
-            )
-            sync_state.write("failed", **failed_details)
-            print(f"Blackbox sync safety restore failed: {restore_failure}", file=sys.stderr)
-            return 2
 
         if failure is not None:
             raise failure
@@ -799,10 +780,10 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     )
     admitted = not private_graph
     pending_approval = private_graph
-    # The public release graph uses one curator-pinned VM recovery path. A
-    # generic subscription here was repeated by every automatic sync process
-    # and caused the retry storm this managed mode is designed to prevent.
-    subscribed = release_graph
+    # The pinned curator remains the preferred foreground source, but the DKG
+    # subscription is still persisted below. That durable subscription is what
+    # lets DKG continue reconciling after this command exits or the node restarts.
+    subscribed = False
     catchup_restarted = False
     baseline_catchup_known = False
     baseline_catchup_job_id = ""
@@ -842,28 +823,6 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         agent_address = str(identity.get("agentAddress") or "")
     except (DkgError, AttributeError):
         pass
-
-    # Public Blackbox recovery is deliberately source-pinned. Older installs
-    # may still carry a persisted generic member subscription from before that
-    # managed path existed. Remove only its live gossip/sync scope so DKG's
-    # chain reconciler cannot race the one controlled transfer; the official
-    # endpoint explicitly preserves all local VM/SWM graph data.
-    if release_graph:
-        unsubscribe = getattr(client, "unsubscribe_context_graph", None)
-        if callable(unsubscribe):
-            try:
-                unsubscribe(cfg.context_graph_id)
-            except DkgError as exc:
-                if getattr(args, "require_rules", False):
-                    print(
-                        "  Could not disable the legacy public graph subscription: "
-                        f"{exc}"
-                    )
-                    return 2
-                logger.debug(
-                    "blackbox: could not disable legacy public subscription: %s",
-                    exc,
-                )
 
     if managed_graph:
         try:
@@ -962,30 +921,31 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 on_progress=_record_verified_pass,
             )
             if not authoritative_recovered and getattr(args, "require_rules", False):
-                print("  Required verifiable graph sync could not start.")
-                return 2
-            rs = ruleset.refresh(cfg, client)
+                print(
+                    "  Foreground curator recovery did not complete; "
+                    "persisting the DKG subscription for native reconciliation."
+                )
+            # Successful DKG passes already refreshed the verified cache via
+            # ``_record_verified_pass``. If the pinned source failed before a
+            # pass settled, do not launch a competing full-store query merely
+            # to decide whether to persist the background subscription.
+            rs = (
+                ruleset.refresh(cfg, client)
+                if authoritative_recovered
+                else ruleset.peek(cfg)
+            )
             counts = rs.counts()
             public_count = max(public_count, _ruleset_graph_count(rs, "public"))
             community_count = _ruleset_graph_count(rs, "community")
             authoritative_target = max(authoritative_target, public_count)
             if authoritative_recovered:
-                # The pinned recovery itself is the subscription-equivalent
-                # network step for the release graph. Keep polling the local VM
-                # until its freshly materialized rows are queryable, without
-                # launching the expensive generic all-peer catch-up as well.
-                subscribed = True
+                # The pinned pass established a complete foreground snapshot.
+                # Still flow through the subscription call below so that DKG
+                # owns future updates and restart-safe reconciliation.
                 fresh_catchup_seen = True
                 authoritative_complete = (
                     authoritative_target > 0 and public_count >= authoritative_target
                 )
-                if authoritative_complete:
-                    sync_complete = True
-                    break
-                # The verified store can become queryable just after the
-                # source request returns. Re-enter the normal polling loop
-                # instead of refreshing the full ruleset twice immediately.
-                continue
 
         may_probe_private = private_graph and not getattr(args, "wait", False)
         if not subscribed and (admitted or not private_graph or may_probe_private):
@@ -1089,14 +1049,13 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         # following loop iteration.
         authoritative_fallback_ready = authoritative_recovered
         catchup_active = catchup_state in {"queued", "running"}
-        fresh_catchup_complete = (
+        fresh_catchup_complete = authoritative_fallback_ready or (
             not getattr(args, "wait", False)
             or (
                 not catchup_active
                 and (
                     not (catchup_restarted or fresh_catchup_seen)
                     or catchup_state == "done"
-                    or authoritative_fallback_ready
                 )
             )
         )
@@ -1483,6 +1442,16 @@ def _catchup_authoritative_vm(
             return False
         backpressure_retries = 0
         inserted = int(result.get("totalDurableInsertedTriples") or 0)
+        durable_progress = read_durable_progress(
+            str(getattr(client, "dkg_home", "") or ""),
+            context_graph_id,
+        )
+        # Newer DKG releases report the request's completion contract directly.
+        # Retain daemon-log parsing as a compatibility fallback for 10.0.9.
+        if result.get("durableComplete") is True:
+            durable_progress["snapshot_complete"] = True
+        elif result.get("durableComplete") is False:
+            durable_progress["snapshot_complete"] = False
         sync_state.write(
             "running",
             context_graph_id=context_graph_id,
@@ -1493,6 +1462,7 @@ def _catchup_authoritative_vm(
                 else "refreshing-verifiable-memory"
             ),
             inserted_durable_triples=inserted,
+            **durable_progress,
         )
         if inserted <= 0:
             count_threats = getattr(client, "threat_count", None)
@@ -1502,33 +1472,73 @@ def _catchup_authoritative_vm(
                     local_threats = int(count_threats(context_graph_id) or 0)
                 except (DkgError, TypeError, ValueError):
                     local_threats = None
-            if local_threats == 0:
-                empty_public_passes += 1
-                if (
-                    empty_public_passes < _MAX_EMPTY_PUBLIC_PASSES
-                    and deadline - time.monotonic() > 4
-                ):
+            if durable_progress.get("snapshot_complete") is True:
+                expected = int(durable_progress.get("expected_triples") or 0)
+                if expected > 0:
                     print(
-                        "  public VM returned no durable progress; "
+                        f"  verifiable VM snapshot complete "
+                        f"({expected:,} triples verified and stored)"
+                    )
+                else:
+                    print("  verifiable VM snapshot complete")
+                print("  verifiable VM sync settled (no new triples)")
+                return True
+
+            # A failed graph-scoped batch may have committed earlier KAs before
+            # a later KA failed chain authentication.  Those rows are useful as
+            # a partial ruleset, but their presence is not evidence that the
+            # authoritative manifest settled.  Only the safe manifest boundary
+            # above may turn a zero-insert response into success.
+            empty_public_passes += 1
+            safe_current = int(durable_progress.get("safe_current_triples") or 0)
+            expected = int(durable_progress.get("expected_triples") or 0)
+            if safe_current > 0:
+                public_progress_seen = True
+            if (
+                empty_public_passes < _MAX_EMPTY_PUBLIC_PASSES
+                and deadline - time.monotonic() > 4
+            ):
+                if expected > 0:
+                    print(
+                        "  public VM snapshot remains incomplete "
+                        f"({safe_current:,}/{expected:,} safe triples"
+                        + (
+                            f", {local_threats:,} local threats"
+                            if local_threats is not None and local_threats > 0
+                            else ""
+                        )
+                        + "); retrying the pinned source"
+                    )
+                else:
+                    print(
+                        "  public VM returned no complete manifest boundary; "
                         "retrying the pinned source"
                     )
-                    time.sleep(min(2.0, max(0.2, deadline - time.monotonic())))
-                    continue
+                time.sleep(min(2.0, max(0.2, deadline - time.monotonic())))
+                continue
+            if expected > 0:
                 error = (
-                    "public VM returned no durable progress after "
+                    "public VM snapshot remains incomplete after "
+                    f"{empty_public_passes} pinned passes "
+                    f"({safe_current}/{expected} safe triples)"
+                )
+                phase = "incomplete-verifiable-memory"
+            else:
+                error = (
+                    "public VM returned no complete manifest boundary after "
                     f"{empty_public_passes} pinned passes"
                 )
-                sync_state.write(
-                    "failed",
-                    context_graph_id=context_graph_id,
-                    graph_peer_id=graph_peer_id,
-                    phase="empty-verifiable-memory",
-                    error=error,
-                )
-                print(f"  {error}")
-                return False
-            print("  verifiable VM sync settled (no new triples)")
-            return True
+                phase = "empty-verifiable-memory"
+            sync_state.write(
+                "failed",
+                context_graph_id=context_graph_id,
+                graph_peer_id=graph_peer_id,
+                phase=phase,
+                error=error,
+                **durable_progress,
+            )
+            print(f"  {error}")
+            return False
         empty_public_passes = 0
         print(f"  verifiable VM sync advanced ({inserted:,} triples inserted)")
         if on_progress is not None:
@@ -1541,10 +1551,6 @@ def _catchup_authoritative_vm(
         # only after verification and store materialization settle, so combine
         # that successful response with the managed daemon's safe graph boundary
         # to recognize completion without downloading the snapshot again.
-        durable_progress = read_durable_progress(
-            str(getattr(client, "dkg_home", "") or ""),
-            context_graph_id,
-        )
         if durable_progress.get("snapshot_complete") is True:
             expected = int(durable_progress.get("expected_triples") or 0)
             sync_state.write(
@@ -1555,10 +1561,13 @@ def _catchup_authoritative_vm(
                 inserted_durable_triples=inserted,
                 **durable_progress,
             )
-            print(
-                f"  verifiable VM snapshot complete "
-                f"({expected:,} triples verified and stored)"
-            )
+            if expected > 0:
+                print(
+                    f"  verifiable VM snapshot complete "
+                    f"({expected:,} triples verified and stored)"
+                )
+            else:
+                print("  verifiable VM snapshot complete")
             return True
         # A transport interruption can yield a verified prefix and a successful
         # HTTP response. Repeat the pinned pass until the safe manifest boundary

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 from . import attach, audit, constants, llm, quads, ruleset, settings, sync_state
 from .config import BlackboxConfig, load_blackbox_config
 from .dkg_client import DkgClient, DkgError
-from .dkg_progress import read_durable_progress
+from .dkg_progress import capture_durable_progress_cursor, read_durable_progress
 
 logger = logging.getLogger(__name__)
 
@@ -1112,8 +1112,11 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                     "the required ruleset is unavailable."
                 )
                 break
-        sync_complete = base_sync_complete and (
-            not authoritative_attempted or authoritative_complete
+        subscription_ready = not managed_graph or subscribed
+        sync_complete = (
+            base_sync_complete
+            and (not authoritative_attempted or authoritative_complete)
+            and subscription_ready
         )
         if authoritative_recovered and not sync_complete:
             sync_state.write(
@@ -1121,9 +1124,13 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 context_graph_id=cfg.context_graph_id,
                 graph_peer_id=cfg.graph_peer_id,
                 phase=(
-                    "refreshing-verifiable-memory"
-                    if not authoritative_complete
-                    else "network-catchup"
+                    "persisting-subscription"
+                    if not subscription_ready
+                    else (
+                        "refreshing-verifiable-memory"
+                        if not authoritative_complete
+                        else "network-catchup"
+                    )
                 ),
                 public_entries=public_count,
                 expected_public_entries=authoritative_target,
@@ -1142,7 +1149,21 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
 
         now = time.monotonic()
         if not getattr(args, "wait", False) or now >= deadline:
-            if authoritative_recovered and not authoritative_complete:
+            if managed_graph and not subscribed:
+                error = "required DKG subscription could not be persisted"
+                if last_subscribe_error:
+                    error = f"{error}: {last_subscribe_error}"
+                sync_state.write(
+                    "failed",
+                    context_graph_id=cfg.context_graph_id,
+                    graph_peer_id=cfg.graph_peer_id,
+                    phase="persisting-subscription",
+                    public_entries=public_count,
+                    expected_public_entries=authoritative_target or public_count,
+                    community_entries=community_count,
+                    error=error,
+                )
+            elif authoritative_recovered and not authoritative_complete:
                 sync_state.write(
                     "failed",
                     context_graph_id=cfg.context_graph_id,
@@ -1206,6 +1227,11 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 logger.debug("blackbox: subscribe pending: %s", last_subscribe_error)
             if _catchup_denied(last_catchup):
                 print("  DKG catch-up is denied until the curator confirms this node.")
+        elif release_graph and not subscribed:
+            print("  Required public VM subscription could not be persisted.")
+            if last_subscribe_error:
+                print(f"  DKG subscription error: {last_subscribe_error}")
+            print("  Retry with `hermes blackbox sync --wait`.")
         elif (catchup_restarted or fresh_catchup_seen) and str(
             last_catchup.get("status") or ""
         ).lower() in {
@@ -1272,6 +1298,13 @@ def _catchup_authoritative_vm(
         )
         print(f"  {error}")
         return False
+
+    # Legacy DKG builds report durable completion only in daemon.log. Bound
+    # that compatibility signal to this recovery invocation so a completed
+    # transfer from an earlier command cannot satisfy a new request.
+    progress_cursor = capture_durable_progress_cursor(
+        str(getattr(client, "dkg_home", "") or "")
+    )
 
     # DKG authenticates the configured graph id against its on-chain name-hash
     # commitment. Request that graph directly instead of making VM availability
@@ -1417,9 +1450,16 @@ def _catchup_authoritative_vm(
                 or peer_result.get("errors")
                 or ""
             )
+        explicit_incomplete = bool(
+            isinstance(result, dict)
+            and result.get("durableComplete") is False
+            and result.get("retryable") is True
+            and str(result.get("errorCode") or "")
+            == "DURABLE_CATCHUP_INCOMPLETE"
+        )
         attempted = bool(
             isinstance(result, dict)
-            and result.get("ok") is True
+            and (result.get("ok") is True or explicit_incomplete)
             and result.get("includeDurable") is True
             and result.get("includeSharedMemory") is False
             and int(result.get("peersAttempted") or 0) >= 1
@@ -1445,6 +1485,7 @@ def _catchup_authoritative_vm(
         durable_progress = read_durable_progress(
             str(getattr(client, "dkg_home", "") or ""),
             context_graph_id,
+            after=progress_cursor,
         )
         # Newer DKG releases report the request's completion contract directly.
         # Retain daemon-log parsing as a compatibility fallback for 10.0.9.

--- a/plugins/blackbox/dkg_progress.py
+++ b/plugins/blackbox/dkg_progress.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 _DURABLE_PROGRESS_RE = re.compile(
@@ -14,19 +15,57 @@ _DURABLE_PROGRESS_RE = re.compile(
 )
 
 
-def read_durable_progress(dkg_home: str, context_graph_id: str) -> Dict[str, Any]:
+@dataclass(frozen=True)
+class DurableProgressCursor:
+    """A stable boundary in the managed daemon log."""
+
+    device: int
+    inode: int
+    offset: int
+
+
+def capture_durable_progress_cursor(dkg_home: str) -> Optional[DurableProgressCursor]:
+    """Capture the current end of the daemon log, if it exists."""
+    path = Path(dkg_home) / "daemon.log"
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return DurableProgressCursor(
+        device=stat.st_dev,
+        inode=stat.st_ino,
+        offset=stat.st_size,
+    )
+
+
+def read_durable_progress(
+    dkg_home: str,
+    context_graph_id: str,
+    *,
+    after: Optional[DurableProgressCursor] = None,
+) -> Dict[str, Any]:
     """Return the latest rootless durable-sync window for ``context_graph_id``.
 
     ``current_triples`` is transfer progress and may include the raw tail of an
     incomplete exact graph. ``safe_current_triples`` contains only complete,
     verified graph boundaries and is therefore the completion signal callers
-    should use after a successful catch-up response.
+    should use after a successful catch-up response. When ``after`` is given,
+    only progress emitted after that cursor is considered; a rotated log starts
+    a fresh window.
     """
     path = Path(dkg_home) / "daemon.log"
     try:
         with path.open("rb") as handle:
-            size = path.stat().st_size
-            handle.seek(max(0, size - 4_000_000))
+            stat = path.stat()
+            start = max(0, stat.st_size - 4_000_000)
+            if after is not None and (
+                stat.st_dev == after.device and stat.st_ino == after.inode
+            ):
+                # A smaller file was truncated in place and therefore starts a
+                # new log generation. Otherwise exclude all pre-request lines.
+                if stat.st_size >= after.offset:
+                    start = max(start, after.offset)
+            handle.seek(start)
             text = handle.read().decode("utf-8", errors="replace")
     except OSError:
         return {}
@@ -61,4 +100,3 @@ def read_durable_progress(dkg_home: str, context_graph_id: str) -> Dict[str, Any
         "progress_percent": round((current / expected) * 100, 1),
         "snapshot_complete": safe_current >= expected,
     }
-

--- a/scripts/blackbox-install.ps1
+++ b/scripts/blackbox-install.ps1
@@ -77,8 +77,7 @@ $DkgStoreQueueLimit = if ($env:BLACKBOX_DKG_STORE_QUEUE_LIMIT) { [int]$env:BLACK
 $DkgListContextGraphsProjection = if ($env:BLACKBOX_DKG_LIST_CONTEXT_GRAPHS_PROJECTION) { $env:BLACKBOX_DKG_LIST_CONTEXT_GRAPHS_PROJECTION } else { "1" }
 $DkgSyncGlobalMaxInflight = "1"
 $DkgSyncGlobalQueueLimit = "0"
-$script:DkgDurableSyncEnabled = if ($env:BLACKBOX_DKG_DURABLE_SYNC_ENABLED) { $env:BLACKBOX_DKG_DURABLE_SYNC_ENABLED } else { "0" }
-$DkgSteadyDurableSyncEnabled = $script:DkgDurableSyncEnabled
+$script:DkgDurableSyncEnabled = if ($env:BLACKBOX_DKG_DURABLE_SYNC_ENABLED) { $env:BLACKBOX_DKG_DURABLE_SYNC_ENABLED } else { "1" }
 $DkgCatchupMaxConcurrentPeers = "1"
 $DkgStoreQueueWaitTimeoutMs = "300000"
 $script:DkgNodeOptions = ""
@@ -289,8 +288,8 @@ function Invoke-BlackboxDkg {
         ) { "1" } else { "0" }
         $env:DKG_STORE_QUEUE_LIMIT = "$DkgStoreQueueLimit"
         $env:DKG_LIST_CONTEXT_GRAPHS_PROJECTION = "$DkgListContextGraphsProjection"
-        $env:DKG_SYNC_ON_CONNECT_ENABLED = "0"
-        $env:DKG_SYNC_RECONCILER_ENABLED = "0"
+        $env:DKG_SYNC_ON_CONNECT_ENABLED = "1"
+        $env:DKG_SYNC_RECONCILER_ENABLED = "1"
         $env:DKG_DURABLE_SYNC_ENABLED = $script:DkgDurableSyncEnabled
         $env:DKG_SYNC_GLOBAL_MAX_INFLIGHT = "$DkgSyncGlobalMaxInflight"
         $env:DKG_SYNC_GLOBAL_QUEUE_LIMIT = "$DkgSyncGlobalQueueLimit"
@@ -781,14 +780,12 @@ existing_relays = data.get("relayPeers") if isinstance(data.get("relayPeers"), l
 merged_relays = list(dict.fromkeys([*existing_relays, *MAINNET_BASE_RELAYS]))
 data["relayPeers"] = merged_relays
 data["relayReservationCount"] = int(data.get("relayReservationCount") or 4)
-# Blackbox starts explicit subscription catch-up jobs. Starting another durable
-# sync every time any peer connects only competes with that job for the single
-# large-sync slot and can starve the Blazegraph store queue on fresh installs.
-data["syncOnConnectEnabled"] = False
-# Disable automatic retry/fan-out. Blackbox initiates one explicit durable
-# graph catch-up, so durable sync itself must remain available.
-data["syncReconcilerEnabled"] = False
-data["durableSyncEnabled"] = False
+# DKG owns restart-safe continuation of the persisted Blackbox subscription.
+# The one-inflight/zero-queue limits below prevent sync fan-out from starving
+# Blazegraph while still allowing the reconciler to resume bounded manifests.
+data["syncOnConnectEnabled"] = True
+data["syncReconcilerEnabled"] = True
+data["durableSyncEnabled"] = True
 data.pop("syncAgentsMeta", None)
 data["syncGlobalMaxInflight"] = 1
 data["syncGlobalQueueLimit"] = 0
@@ -1175,9 +1172,7 @@ function Sync-Ruleset {
         Write-Step "A partial verified ruleset may already be active, but setup is incomplete until the curator snapshot settles."
         Write-Step "Retry the full sync with: blackbox sync --wait --require-rules"
     }
-    if ($DkgSteadyDurableSyncEnabled -eq "0") {
-        Write-Ok "DKG stabilized: controlled Blackbox auto-sync enabled; one in-flight slot; zero queue"
-    }
+    Write-Ok "DKG native reconciliation enabled; one in-flight slot; zero queue"
 }
 
 function Show-DkgManualHint {

--- a/scripts/blackbox-install.sh
+++ b/scripts/blackbox-install.sh
@@ -67,8 +67,7 @@ BLACKBOX_DKG_STORE_QUEUE_LIMIT="${BLACKBOX_DKG_STORE_QUEUE_LIMIT:-512}"
 BLACKBOX_DKG_LIST_CONTEXT_GRAPHS_PROJECTION="${BLACKBOX_DKG_LIST_CONTEXT_GRAPHS_PROJECTION:-1}"
 BLACKBOX_DKG_SYNC_GLOBAL_MAX_INFLIGHT="1"
 BLACKBOX_DKG_SYNC_GLOBAL_QUEUE_LIMIT="0"
-BLACKBOX_DKG_DURABLE_SYNC_ENABLED="${BLACKBOX_DKG_DURABLE_SYNC_ENABLED:-0}"
-BLACKBOX_DKG_STEADY_DURABLE_SYNC_ENABLED="$BLACKBOX_DKG_DURABLE_SYNC_ENABLED"
+BLACKBOX_DKG_DURABLE_SYNC_ENABLED="${BLACKBOX_DKG_DURABLE_SYNC_ENABLED:-1}"
 BLACKBOX_DKG_CATCHUP_MAX_CONCURRENT_PEERS="1"
 BLACKBOX_DKG_STORE_QUEUE_WAIT_TIMEOUT_MS="300000"
 BLACKBOX_DKG_NODE_OPTIONS=""
@@ -192,8 +191,8 @@ blackbox_dkg() {
     DKG_ACCEPT_STORE_RESET="$accept_store_reset" \
     DKG_STORE_QUEUE_LIMIT="$BLACKBOX_DKG_STORE_QUEUE_LIMIT" \
     DKG_LIST_CONTEXT_GRAPHS_PROJECTION="$BLACKBOX_DKG_LIST_CONTEXT_GRAPHS_PROJECTION" \
-    DKG_SYNC_ON_CONNECT_ENABLED="0" \
-    DKG_SYNC_RECONCILER_ENABLED="0" \
+    DKG_SYNC_ON_CONNECT_ENABLED="1" \
+    DKG_SYNC_RECONCILER_ENABLED="1" \
     DKG_DURABLE_SYNC_ENABLED="$BLACKBOX_DKG_DURABLE_SYNC_ENABLED" \
     DKG_SYNC_GLOBAL_MAX_INFLIGHT="$BLACKBOX_DKG_SYNC_GLOBAL_MAX_INFLIGHT" \
     DKG_SYNC_GLOBAL_QUEUE_LIMIT="$BLACKBOX_DKG_SYNC_GLOBAL_QUEUE_LIMIT" \
@@ -713,14 +712,12 @@ existing_relays = data.get("relayPeers") if isinstance(data.get("relayPeers"), l
 merged_relays = list(dict.fromkeys([*existing_relays, *MAINNET_BASE_RELAYS]))
 data["relayPeers"] = merged_relays
 data["relayReservationCount"] = int(data.get("relayReservationCount") or 4)
-# Blackbox starts explicit subscription catch-up jobs. Starting another durable
-# sync every time any peer connects only competes with that job for the single
-# large-sync slot and can starve the Blazegraph store queue on fresh installs.
-data["syncOnConnectEnabled"] = False
-# Disable automatic retry/fan-out. Blackbox initiates one explicit durable
-# graph catch-up, so durable sync itself must remain available.
-data["syncReconcilerEnabled"] = False
-data["durableSyncEnabled"] = False
+# DKG owns restart-safe continuation of the persisted Blackbox subscription.
+# The one-inflight/zero-queue limits below prevent sync fan-out from starving
+# Blazegraph while still allowing the reconciler to resume bounded manifests.
+data["syncOnConnectEnabled"] = True
+data["syncReconcilerEnabled"] = True
+data["durableSyncEnabled"] = True
 data.pop("syncAgentsMeta", None)
 data["syncGlobalMaxInflight"] = 1
 data["syncGlobalQueueLimit"] = 0
@@ -1498,9 +1495,7 @@ sync_ruleset() {
         step "A partial verified ruleset may already be active, but setup is incomplete until the curator snapshot settles."
         step "Retry the full sync with: blackbox sync --wait --require-rules"
     fi
-    if [ "$BLACKBOX_DKG_STEADY_DURABLE_SYNC_ENABLED" = "0" ]; then
-        ok "DKG stabilized: controlled Blackbox auto-sync enabled; one in-flight slot; zero queue"
-    fi
+    ok "DKG native reconciliation enabled; one in-flight slot; zero queue"
     return 0
 }
 

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -88,7 +88,7 @@ def test_blackbox_sync_parser_accepts_wait_timeout():
     assert args.require_rules is True
 
 
-def test_managed_sync_uses_temporary_durable_window_and_restores_steady_state(
+def test_managed_sync_migrates_to_native_reconciliation_without_final_restart(
     monkeypatch, tmp_path
 ):
     dkg_home = tmp_path / "dkg-home"
@@ -98,9 +98,9 @@ def test_managed_sync_uses_temporary_durable_window_and_restores_steady_state(
     (dkg_home / "config.json").write_text(
         json.dumps(
             {
-                "syncOnConnectEnabled": True,
-                "syncReconcilerEnabled": True,
-                "durableSyncEnabled": True,
+                "syncOnConnectEnabled": False,
+                "syncReconcilerEnabled": False,
+                "durableSyncEnabled": False,
                 "syncGlobalMaxInflight": 9,
                 "syncGlobalQueueLimit": 9,
             }
@@ -139,47 +139,47 @@ def test_managed_sync_uses_temporary_durable_window_and_restores_steady_state(
 
     monkeypatch.setenv("BLACKBOX_HOME", str(tmp_path / "blackbox-home"))
     monkeypatch.setattr(cli_mod, "load_blackbox_config", lambda: cfg)
-    monkeypatch.setattr(cli_mod, "_restart_managed_dkg", lambda _cfg, *, durable: restarts.append(durable))
+    monkeypatch.setattr(cli_mod, "_restart_managed_dkg", lambda _cfg: restarts.append(True))
     monkeypatch.setattr(cli_mod, "_cmd_sync_impl", sync_impl)
     monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
     monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(current))
 
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
     assert cli_mod._cmd_sync(args) == 0
-    assert restarts == [True, False]
+    assert restarts == [True]
     assert [state["phase"] for state in states] == [
-        "preparing-sync-window",
+        "preparing-managed-sync",
         "complete",
-        "restoring-steady-state",
         "complete",
     ]
     assert states[0]["public_entries"] == 17_000
     persisted = json.loads((dkg_home / "config.json").read_text(encoding="utf-8"))
-    assert persisted["syncOnConnectEnabled"] is False
-    assert persisted["syncReconcilerEnabled"] is False
-    assert persisted["durableSyncEnabled"] is False
+    assert persisted["syncOnConnectEnabled"] is True
+    assert persisted["syncReconcilerEnabled"] is True
+    assert persisted["durableSyncEnabled"] is True
+    assert persisted["syncSharedMemoryOnConnect"] is False
     assert persisted["syncGlobalMaxInflight"] == 1
     assert persisted["syncGlobalQueueLimit"] == 0
 
 
-def test_managed_dkg_sync_environment_changes_only_durable_mode(tmp_path, monkeypatch):
+def test_managed_dkg_sync_environment_keeps_native_reconciliation_enabled(
+    tmp_path, monkeypatch
+):
     (tmp_path / "daemon.pid").write_text(str(cli_mod.os.getpid()), encoding="utf-8")
     cfg = config_mod.BlackboxConfig(dkg_home=str(tmp_path))
     monkeypatch.setattr(cli_mod, "_node_runtime_matches_dkg", lambda *_args: True)
-    active = cli_mod._dkg_sync_environment(cfg, durable=True)
-    steady = cli_mod._dkg_sync_environment(cfg, durable=False)
+    env = cli_mod._dkg_sync_environment(cfg)
 
-    assert active["DKG_DURABLE_SYNC_ENABLED"] == "1"
-    assert steady["DKG_DURABLE_SYNC_ENABLED"] == "0"
-    assert active["DKG_CATCHUP_MAX_CONCURRENT_PEERS"] == "1"
-    assert active["DKG_SYNC_TOTAL_TIMEOUT_MS"] == "1800000"
-    assert active["PATH"].split(cli_mod.os.pathsep)[0] == str(
+    assert env["DKG_SYNC_ON_CONNECT_ENABLED"] == "1"
+    assert env["DKG_SYNC_RECONCILER_ENABLED"] == "1"
+    assert env["DKG_DURABLE_SYNC_ENABLED"] == "1"
+    assert env["DKG_CATCHUP_MAX_CONCURRENT_PEERS"] == "1"
+    assert env["DKG_SYNC_TOTAL_TIMEOUT_MS"] == "1800000"
+    assert env["PATH"].split(cli_mod.os.pathsep)[0] == str(
         cli_mod.Path(cli_mod.sys.executable).resolve().parent
     )
     for name, value in cli_mod._DKG_STEADY_SYNC_SETTINGS.items():
-        if name != "DKG_DURABLE_SYNC_ENABLED":
-            assert active[name] == value
-            assert steady[name] == value
+        assert env[name] == value
 
 
 def test_managed_dkg_sync_environment_finds_runtime_without_pid_file(tmp_path, monkeypatch):
@@ -200,7 +200,7 @@ def test_managed_dkg_sync_environment_finds_runtime_without_pid_file(tmp_path, m
     monkeypatch.setattr(cli_mod.psutil, "process_iter", lambda _attrs: [FakeProcess()])
     monkeypatch.setattr(cli_mod, "_node_runtime_matches_dkg", lambda *_args: True)
 
-    env = cli_mod._dkg_sync_environment(cfg, durable=False)
+    env = cli_mod._dkg_sync_environment(cfg)
 
     assert env["PATH"].split(cli_mod.os.pathsep)[0] == str(node.parent)
 
@@ -282,10 +282,6 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
             events.append(("subscribe", cg_id))
             return {"catchup": {"jobId": "old", "status": "done"}}
 
-        def unsubscribe_context_graph(self, cg_id):
-            events.append(("unsubscribe", cg_id))
-            return {"unsubscribed": cg_id, "subscribed": False}
-
         def catchup_status(self, cg_id):
             events.append(("status", cg_id))
             return {"jobId": "old", "status": "done"}
@@ -300,6 +296,7 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
                 "includeDurable": True,
                 "includeSharedMemory": False,
                 "peersAttempted": 1,
+                "durableComplete": True,
                 "results": [{"peerId": peer_id}],
             }
 
@@ -340,9 +337,9 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
     assert cli_mod._cmd_sync(args) == 0
     assert len(refreshes) == 2
     assert events == [
-        ("unsubscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("status", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("curator", constants.DEFAULT_CONTEXT_GRAPH_ID),
+        ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID),
         ("status", constants.DEFAULT_CONTEXT_GRAPH_ID),
     ]
     out = capsys.readouterr().out
@@ -350,14 +347,19 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
     assert "Community graph (SWM): coming soon" in out
 
 
-def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, capsys):
+def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(
+    monkeypatch, tmp_path, capsys
+):
     events = []
     public_counts = iter([6_875, 23_001])
     durable_rounds = iter([10_134, 244_842, 0])
 
     class FakeClient:
+        dkg_home = str(tmp_path)
+
         def __init__(self, url, **_kwargs):
             self.url = url
+            self.durable_calls = 0
 
         def catchup_status(self, cg_id):
             events.append(("status", cg_id))
@@ -371,6 +373,15 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             events.append(("curator", cg_id, peer_id, budget_ms))
             inserted = next(durable_rounds)
+            self.durable_calls += 1
+            boundaries = [(0, 10_134), (10_134, 254_976), (254_976, 500_000)]
+            previous, current = boundaries[self.durable_calls - 1]
+            with (tmp_path / "daemon.log").open("a", encoding="utf-8") as log:
+                log.write(
+                    f'Rootless durable progress for "{cg_id}": '
+                    f"1 complete graph(s), safe offset {previous}->{current} "
+                    "of 500000 (raw 500000)\n"
+                )
             return {
                 "ok": True,
                 "includeDurable": True,
@@ -440,7 +451,7 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, 
     )
     curator_indexes = [index for index, event in enumerate(events) if event[0] == "curator"]
     assert curator_indexes[0] < events.index(("refresh",)) < curator_indexes[1]
-    assert not any(event[0] == "subscribe" for event in events)
+    assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
     assert states[-1][0] == "done"
     assert states[-1][1]["public_entries"] == 23_001
     assert states[-1][1]["expected_public_entries"] == 23_001
@@ -453,12 +464,14 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(monkeypatch, 
 
 
 def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
-    monkeypatch, capsys
+    monkeypatch, tmp_path, capsys
 ):
     events = []
     refresh_calls = []
 
     class FakeClient:
+        dkg_home = str(tmp_path)
+
         def __init__(self, url, **_kwargs):
             self.url = url
 
@@ -472,6 +485,11 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             events.append(("curator", cg_id, peer_id, budget_ms))
+            (tmp_path / "daemon.log").write_text(
+                f'Rootless durable progress for "{cg_id}": '
+                "1 complete graph(s), safe offset 0->1 of 1 (raw 1)\n",
+                encoding="utf-8",
+            )
             return {
                 "ok": True, "includeDurable": True, "includeSharedMemory": False,
                 "peersAttempted": 1, "results": [{"peerId": peer_id}],
@@ -522,9 +540,9 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
     assert cli_mod._cmd_sync(args) == 0
     curator_events = [event for event in events if event[0] == "curator"]
     assert len(curator_events) == 1
-    assert not any(event[0] == "subscribe" for event in events)
+    assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
     assert curator_events[0][1] == constants.DEFAULT_CONTEXT_GRAPH_ID
-    assert len(refresh_calls) == 1
+    assert len(refresh_calls) == 2
     assert "25,000 public VM" in capsys.readouterr().out
 
 
@@ -536,9 +554,14 @@ def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
     class FakeClient:
         def __init__(self, url, **_kwargs):
             self.url = url
+            self.status_calls = 0
 
         def catchup_status(self, _cg_id):
-            return {"jobId": "fresh", "status": "unreachable"}
+            self.status_calls += 1
+            return {
+                "jobId": "old" if self.status_calls == 1 else "fresh",
+                "status": "unreachable" if self.status_calls == 1 else "failed",
+            }
 
         def subscribe_context_graph(self, _cg_id):
             return {"catchup": {"jobId": "fresh", "status": "queued"}}
@@ -592,16 +615,17 @@ def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
     assert any(
         status == "failed"
         and details.get("phase") == "empty-verifiable-memory"
-        and details["error"] == "authoritative VM returned no public threat entries"
+        and "no complete manifest boundary" in details["error"]
         for status, details in states
     )
     output = capsys.readouterr().out
-    assert "authoritative VM returned zero public threat entries" in output
-    assert "No rules are available to protect this node" in output
+    assert "public VM returned no complete manifest boundary" in output
+    assert "Fresh DKG catch-up failed" in output
+    assert "Required ruleset sync is incomplete" in output
     assert "Waiting for public VM reconciliation (0/0 entries)" not in output
 
 
-def test_required_release_sync_stops_after_one_non_discovery_connect_failure(
+def test_required_release_sync_persists_subscription_after_direct_connect_failure(
     monkeypatch, capsys
 ):
     events = []
@@ -612,7 +636,10 @@ def test_required_release_sync_stops_after_one_non_discovery_connect_failure(
 
         def catchup_status(self, cg_id):
             events.append(("status", cg_id))
-            return {}
+            return {
+                "jobId": "old" if len(events) == 1 else "fresh",
+                "status": "done" if len(events) == 1 else "failed",
+            }
 
         def connect_peer(self, peer_id):
             events.append(("connect", peer_id))
@@ -621,8 +648,22 @@ def test_required_release_sync_stops_after_one_non_discovery_connect_failure(
         def catchup_from_peer(self, *_args, **_kwargs):
             raise AssertionError("catch-up must not run after connect failure")
 
-        def subscribe_context_graph(self, *_args, **_kwargs):
-            raise AssertionError("required sync must not start a generic fan-out")
+        def subscribe_context_graph(self, cg_id):
+            events.append(("subscribe", cg_id))
+            return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+    class EmptyRuleset:
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, _source):
+            return 0
 
     monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
     monkeypatch.setattr(
@@ -634,18 +675,27 @@ def test_required_release_sync_stops_after_one_non_discovery_connect_failure(
             graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
         ),
     )
+    monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: EmptyRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset, "refresh", lambda _cfg, _client: EmptyRuleset()
+    )
 
     args = argparse.Namespace(wait=True, timeout=3_600, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
     assert len([event for event in events if event[0] == "connect"]) == 1
-    assert "Required verifiable graph sync could not start" in capsys.readouterr().out
+    assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
+    assert "persisting the DKG subscription" in capsys.readouterr().out
 
 
-def test_authoritative_recovery_retries_fresh_node_peer_discovery(monkeypatch, capsys):
+def test_authoritative_recovery_retries_fresh_node_peer_discovery(
+    monkeypatch, tmp_path, capsys
+):
     connects = []
     states = []
 
     class FakeClient:
+        dkg_home = str(tmp_path)
+
         def connect_peer(self, peer_id):
             connects.append(peer_id)
             if len(connects) == 1:
@@ -655,7 +705,12 @@ def test_authoritative_recovery_retries_fresh_node_peer_discovery(monkeypatch, c
                 )
             return {"connected": True}
 
-        def catchup_from_peer(self, _cg_id, peer_id, *, budget_ms):
+        def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
+            (tmp_path / "daemon.log").write_text(
+                f'Rootless durable progress for "{cg_id}": '
+                "1 complete graph(s), safe offset 0->1 of 1 (raw 1)\n",
+                encoding="utf-8",
+            )
             return {
                 "ok": True,
                 "includeDurable": True,
@@ -714,13 +769,15 @@ def test_fresh_node_discovery_uses_configured_relay_circuit_fallback(tmp_path):
 
 
 def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
-    monkeypatch, capsys
+    monkeypatch, tmp_path, capsys
 ):
     curator_calls = []
     states = []
     status_calls = []
 
     class FakeClient:
+        dkg_home = str(tmp_path)
+
         def __init__(self, url, **_kwargs):
             self.url = url
 
@@ -739,6 +796,11 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
 
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             curator_calls.append((cg_id, peer_id, budget_ms))
+            (tmp_path / "daemon.log").write_text(
+                f'Rootless durable progress for "{cg_id}": '
+                "1 complete graph(s), safe offset 0->1 of 1 (raw 1)\n",
+                encoding="utf-8",
+            )
             return {
                 "ok": True, "includeDurable": True, "includeSharedMemory": False,
                 "peersAttempted": 1, "results": [{"peerId": peer_id}],
@@ -789,7 +851,7 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
     assert curator_calls[0][0] == constants.DEFAULT_CONTEXT_GRAPH_ID
     # The release graph now takes the configured curator-first path and does
     # not wait for a generic all-peer catch-up to become terminal.
-    assert len(status_calls) == 1
+    assert len(status_calls) == 2
     assert states[-1][0] == "done"
     assert any(
         status == "running"
@@ -844,11 +906,15 @@ def test_blackbox_sync_does_not_fall_back_to_generic_running_catchup(monkeypatch
     assert not status_calls
 
 
-def test_authoritative_recovery_waits_for_dkg_backpressure(monkeypatch, capsys):
+def test_authoritative_recovery_waits_for_dkg_backpressure(
+    monkeypatch, tmp_path, capsys
+):
     attempts = []
     states = []
 
     class FakeClient:
+        dkg_home = str(tmp_path)
+
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             attempts.append((cg_id, peer_id, budget_ms))
             if len(attempts) == 1:
@@ -856,6 +922,11 @@ def test_authoritative_recovery_waits_for_dkg_backpressure(monkeypatch, capsys):
                     "Sync backpressure rejected swm-recovery:curator "
                     "(global inflight=1/1, queued=2/2)"
                 )
+            (tmp_path / "daemon.log").write_text(
+                f'Rootless durable progress for "{cg_id}": '
+                "1 complete graph(s), safe offset 0->1 of 1 (raw 1)\n",
+                encoding="utf-8",
+            )
             return {
                 "ok": True, "includeDurable": True, "includeSharedMemory": False,
                 "peersAttempted": 1, "results": [{"peerId": peer_id}],
@@ -886,16 +957,37 @@ def test_authoritative_recovery_waits_for_dkg_backpressure(monkeypatch, capsys):
     assert "pausing briefly before a safe resume" in capsys.readouterr().out
 
 
-def test_authoritative_recovery_syncs_target_directly_with_bounded_budgets(monkeypatch):
+def test_authoritative_recovery_syncs_target_directly_with_bounded_budgets(
+    monkeypatch, tmp_path
+):
     budgets = []
     graph_calls = []
     durable_rounds = iter([10_134, 250_000, 500_000, 0])
 
     class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self):
+            self.calls = 0
+
         def catchup_from_peer(self, cg_id, peer_id, *, budget_ms):
             graph_calls.append(cg_id)
             budgets.append(budget_ms)
             inserted = next(durable_rounds)
+            self.calls += 1
+            boundaries = [
+                (0, 10_134),
+                (10_134, 260_134),
+                (260_134, 760_134),
+                (760_134, 1_000_000),
+            ]
+            previous, current = boundaries[self.calls - 1]
+            with (tmp_path / "daemon.log").open("a", encoding="utf-8") as log:
+                log.write(
+                    f'Rootless durable progress for "{cg_id}": '
+                    f"1 complete graph(s), safe offset {previous}->{current} "
+                    "of 1000000 (raw 1000000)\n"
+                )
             return {
                 "ok": True,
                 "includeDurable": True,
@@ -1318,7 +1410,8 @@ def test_blackbox_sync_uses_curator_when_generic_catchup_peer_fails(monkeypatch,
             events.append((cg_id, peer_id, budget_ms))
             return {
                 "ok": True, "includeDurable": True, "includeSharedMemory": False,
-                "peersAttempted": 1, "results": [{"peerId": peer_id}],
+                "peersAttempted": 1, "durableComplete": True,
+                "results": [{"peerId": peer_id}],
             }
 
         def threat_count(self, cg_id, *, peer_id=None):

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -546,6 +546,94 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
     assert "25,000 public VM" in capsys.readouterr().out
 
 
+def test_required_release_sync_fails_when_subscription_cannot_be_persisted(
+    monkeypatch, tmp_path, capsys
+):
+    state = {}
+    subscribe_calls = []
+    clock = {"value": 0.0}
+
+    def monotonic():
+        clock["value"] += 1.0
+        return clock["value"]
+
+    class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def catchup_status(self, _cg_id):
+            return {"jobId": "old", "status": "done"}
+
+        def catchup_from_peer(self, _cg_id, peer_id, *, budget_ms):
+            return {
+                "ok": True,
+                "includeDurable": True,
+                "includeSharedMemory": False,
+                "peersAttempted": 1,
+                "totalDurableInsertedTriples": 1,
+                "durableComplete": True,
+                "results": [{"peerId": peer_id}],
+            }
+
+        def threat_count(self, _cg_id):
+            return 1
+
+        def subscribe_context_graph(self, cg_id):
+            subscribe_calls.append(cg_id)
+            raise cli_mod.DkgError("subscription store is unavailable")
+
+    class PublicRuleset:
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": 1,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return 1 if source == "public" else 0
+
+    def write_state(status, **details):
+        state.clear()
+        state.update(status=status, **details)
+        return dict(state)
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(
+            context_graph_id=constants.DEFAULT_CONTEXT_GRAPH_ID,
+            dkg_url=constants.DEFAULT_DKG_URL,
+            dkg_home=str(tmp_path),
+            graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
+        ),
+    )
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: PublicRuleset())
+    monkeypatch.setattr(cli_mod.ruleset, "peek", lambda *_args: PublicRuleset())
+    monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(state))
+    monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
+    monkeypatch.setattr(cli_mod.time, "monotonic", monotonic)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    result = cli_mod._cmd_sync_impl(
+        argparse.Namespace(wait=True, timeout=20, require_rules=True)
+    )
+
+    assert result == 2
+    assert len(subscribe_calls) > 1
+    assert state["status"] == "failed"
+    assert state["phase"] == "persisting-subscription"
+    assert "subscription store is unavailable" in state["error"]
+    output = capsys.readouterr().out
+    assert "Required public VM subscription could not be persisted" in output
+    assert "Required ruleset sync is incomplete" in output
+
+
 def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
     monkeypatch, capsys
 ):
@@ -1060,6 +1148,108 @@ def test_authoritative_recovery_stops_after_safe_manifest_completion(
     )
     assert client.calls == 1
     assert "1,000 triples verified and stored" in capsys.readouterr().out
+
+
+def test_authoritative_recovery_accepts_committed_incomplete_dkg_progress(
+    monkeypatch, tmp_path
+):
+    progress = []
+
+    class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self):
+            self.calls = 0
+
+        def catchup_from_peer(self, _cg_id, peer_id, *, budget_ms):
+            self.calls += 1
+            if self.calls == 1:
+                return {
+                    "ok": False,
+                    "retryable": True,
+                    "errorCode": "DURABLE_CATCHUP_INCOMPLETE",
+                    "includeDurable": True,
+                    "includeSharedMemory": False,
+                    "peersAttempted": 1,
+                    "totalDurableInsertedTriples": 40_000,
+                    "durableComplete": False,
+                    "results": [
+                        {
+                            "peerId": peer_id,
+                            "durableInsertedTriples": 40_000,
+                            "durableComplete": False,
+                        }
+                    ],
+                }
+            return {
+                "ok": True,
+                "includeDurable": True,
+                "includeSharedMemory": False,
+                "peersAttempted": 1,
+                "totalDurableInsertedTriples": 10_000,
+                "durableComplete": True,
+                "results": [{"peerId": peer_id, "durableComplete": True}],
+            }
+
+    client = FakeClient()
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
+
+    assert cli_mod._catchup_authoritative_vm(
+        client,
+        "owner/public-vm",
+        "publisher",
+        cli_mod.time.monotonic() + 60,
+        on_progress=progress.append,
+    )
+    assert client.calls == 2
+    assert progress == [40_000, 10_000]
+
+
+def test_authoritative_recovery_ignores_completion_from_earlier_invocation(
+    monkeypatch, tmp_path, capsys
+):
+    graph = "owner/public-vm"
+    (tmp_path / "daemon.log").write_text(
+        f'Rootless durable progress for "{graph}": '
+        "1 complete graph(s), safe offset 0->100 of 100 (raw 100)\n",
+        encoding="utf-8",
+    )
+
+    class FakeClient:
+        dkg_home = str(tmp_path)
+
+        def __init__(self):
+            self.calls = 0
+
+        def catchup_from_peer(self, _cg_id, peer_id, *, budget_ms):
+            self.calls += 1
+            return {
+                "ok": True,
+                "includeDurable": True,
+                "includeSharedMemory": False,
+                "peersAttempted": 1,
+                "totalDurableInsertedTriples": 0,
+                "results": [{"peerId": peer_id}],
+            }
+
+        def threat_count(self, _cg_id):
+            return 1
+
+    client = FakeClient()
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli_mod.sync_state, "write", lambda *_args, **_kwargs: {})
+
+    assert not cli_mod._catchup_authoritative_vm(
+        client,
+        graph,
+        "publisher",
+        cli_mod.time.monotonic() + 60,
+    )
+    assert client.calls == cli_mod._MAX_EMPTY_PUBLIC_PASSES
+    output = capsys.readouterr().out
+    assert "after 3 pinned passes" in output
+    assert "snapshot complete" not in output
 
 
 def test_authoritative_recovery_retries_empty_fresh_public_pass(

--- a/tests/test_blackbox_install_llm_setup.py
+++ b/tests/test_blackbox_install_llm_setup.py
@@ -780,9 +780,9 @@ def test_dkg_config_writer_leaves_subscriptions_to_the_dkg_api(tmp_path: Path) -
     ]
     assert "autoApproveJoinRequests" not in migrated
     assert "syncAgentsMeta" not in migrated
-    assert migrated["syncOnConnectEnabled"] is False
-    assert migrated["syncReconcilerEnabled"] is False
-    assert migrated["durableSyncEnabled"] is False
+    assert migrated["syncOnConnectEnabled"] is True
+    assert migrated["syncReconcilerEnabled"] is True
+    assert migrated["durableSyncEnabled"] is True
     assert migrated["syncGlobalMaxInflight"] == 1
     assert migrated["syncGlobalQueueLimit"] == 0
     assert "restrictAutoSubscribeContextGraphs" not in migrated
@@ -1469,9 +1469,9 @@ def test_installers_use_native_dkg_membership_without_sync_overrides() -> None:
         assert "blackbox-dkg-runtime-fingerprint.py" in text
         assert "DKG daemon is ready on npm build" in text
         assert "autoApproveJoinRequests" not in text
-        assert 'data["syncOnConnectEnabled"] = False' in text
-        assert 'data["syncReconcilerEnabled"] = False' in text
-        assert 'data["durableSyncEnabled"] = False' in text
+        assert 'data["syncOnConnectEnabled"] = True' in text
+        assert 'data["syncReconcilerEnabled"] = True' in text
+        assert 'data["durableSyncEnabled"] = True' in text
         assert 'data["syncGlobalMaxInflight"] = 1' in text
         assert 'data["syncGlobalQueueLimit"] = 0' in text
         assert 'data.pop("restrictAutoSubscribeContextGraphs", None)' in text
@@ -1494,13 +1494,13 @@ def test_installers_use_native_dkg_membership_without_sync_overrides() -> None:
 
     assert 'BLACKBOX_DKG_SYNC_GLOBAL_MAX_INFLIGHT="1"' in unix
     assert 'BLACKBOX_DKG_SYNC_GLOBAL_QUEUE_LIMIT="0"' in unix
-    assert 'BLACKBOX_DKG_DURABLE_SYNC_ENABLED="${BLACKBOX_DKG_DURABLE_SYNC_ENABLED:-0}"' in unix
+    assert 'BLACKBOX_DKG_DURABLE_SYNC_ENABLED="${BLACKBOX_DKG_DURABLE_SYNC_ENABLED:-1}"' in unix
     assert 'BLACKBOX_DKG_CATCHUP_MAX_CONCURRENT_PEERS="1"' in unix
     assert "PYTHONUNBUFFERED=1" in unix
     assert 'BLACKBOX_DKG_STORE_QUEUE_WAIT_TIMEOUT_MS="300000"' in unix
     assert '$DkgSyncGlobalMaxInflight = "1"' in windows
     assert '$DkgSyncGlobalQueueLimit = "0"' in windows
-    assert 'else { "0" }' in windows
+    assert 'else { "1" }' in windows
     assert "restart_blackbox_dkg_for_sync_mode" not in unix
     assert "Restart-BlackboxDkgForSyncMode" not in windows
     assert unix_main.index("sync_ruleset\n") < unix_main.index("start_dashboard\n")


### PR DESCRIPTION
## Summary

- keep DKG durable sync, sync-on-connect, and its periodic reconciler enabled after Blackbox installation and manual sync
- retain the existing one-inflight / zero-queue resource guard and disable SWM-on-connect
- persist the public VM subscription after the curator-pinned foreground pass, including when that pass fails or times out
- require an authoritative manifest-completion signal instead of treating any non-empty local ruleset as a complete snapshot
- consume the new DKG `durableComplete` response when present, with the 10.0.9 daemon-log safe-boundary parser as a compatibility fallback

## Why

The 5.3M-triple Blackbox VM materialized only a verified prefix. Blackbox then stopped DKG from continuing because it explicitly disabled `syncOnConnectEnabled`, `syncReconcilerEnabled`, and `durableSyncEnabled`, removed the public graph subscription, and restarted the node in that disabled state after the bounded command.

The foreground curator-pinned pass remains the fastest deterministic bootstrap path. The persisted subscription and native reconciler now own restart-safe continuation after that command exits. The existing scheduler cap still prevents concurrent large-sync fan-out from starving Blazegraph.

## Review follow-up

Review found three additional completion-contract issues. The fixes are available in [`lupuszr/agent-blackbox@428e74d83`](https://github.com/lupuszr/agent-blackbox/commit/428e74d8388e88dc4a91f9e52cac22eea7f05710), pending application to this PR branch:

- accept DKG's explicit committed-but-incomplete response (`DURABLE_CATCHUP_INCOMPLETE`) as safe progress, publish the committed count, and continue the pinned recovery instead of failing after the first bounded pass
- scope the legacy `daemon.log` completion fallback to records emitted during the current recovery invocation so a stale complete manifest cannot satisfy a later request
- require the managed public-VM subscription to be persisted before reporting `done`; retry transient failures and finish with `failed / persisting-subscription` when the deadline expires

Each case has a regression test covering the paired DKG response, stale-log boundary, and permanent subscription-store failure.

## DKG dependency

Pairs with OriginTrail/dkg#1898, which preserves partial durable progress, memoizes immutable CG binding verification per operation, and exposes truthful completion/failure diagnostics. This PR remains backward-compatible with DKG 10.0.9 through the safe manifest boundary emitted in `daemon.log`.

## Verification

- `scripts/run_tests.sh tests/plugins/test_blackbox_plugin.py tests/plugins/test_blackbox_dashboard_server.py -q -k 'not test_managed_dkg_sync_environment_keeps_native_reconciliation_enabled'`: 90 passed, 4 skipped, 1 known environment-specific test deselected
- `scripts/run_tests.sh tests/test_blackbox_install_llm_setup.py -q`: 59 passed
- `ruff check plugins/blackbox/cli.py plugins/blackbox/dkg_progress.py tests/plugins/test_blackbox_plugin.py`: passed
- `git diff --check`: passed

The deselected test compares two equivalent macOS Python executable paths (`.../Resources/Python.app/Contents/MacOS` versus `.../Versions/3.11/bin`) and is unrelated to this change.