### PR TITLE
fix(blackbox): serialize custom graph cache refresh

### DIFF
--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -468,7 +468,7 @@ def _cmd_sync(args: argparse.Namespace) -> int:
             with _managed_sync_lock() as acquired:
                 if not acquired:
                     print("Blackbox sync is already running; no second transfer was queued.")
-                    return 0
+                    return 2 if getattr(args, "require_rules", False) else 0
                 return _cmd_sync_impl(args)
         return _cmd_sync_impl(args)
     except KeyboardInterrupt:
@@ -718,8 +718,12 @@ def _terminal_sync_details(state: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _last_sync_counts() -> tuple[int, int]:
-    previous = sync_state.read()
+def _last_sync_counts(context_graph_id: str = "") -> tuple[int, int]:
+    previous = (
+        sync_state.read_for_graph(context_graph_id)
+        if context_graph_id
+        else sync_state.read()
+    )
     try:
         public = max(0, int(previous.get("public_entries") or 0))
     except (TypeError, ValueError):
@@ -736,9 +740,9 @@ def _cmd_sync_with_managed_dkg(cfg: BlackboxConfig, args: argparse.Namespace) ->
     with _managed_sync_lock() as acquired:
         if not acquired:
             print("Blackbox sync is already running; no second transfer was queued.")
-            return 0
+            return 2 if getattr(args, "require_rules", False) else 0
 
-        known_public, known_community = _last_sync_counts()
+        known_public, known_community = _last_sync_counts(cfg.context_graph_id)
         sync_state.write(
             "running",
             context_graph_id=cfg.context_graph_id,
@@ -758,10 +762,10 @@ def _cmd_sync_with_managed_dkg(cfg: BlackboxConfig, args: argparse.Namespace) ->
             if _set_persisted_dkg_steady_state(cfg):
                 _restart_managed_dkg(cfg)
             result = _cmd_sync_impl(args)
-            terminal_state = sync_state.read()
+            terminal_state = sync_state.read_for_graph(cfg.context_graph_id)
         except BaseException as exc:
             failure = exc
-            terminal_state = sync_state.read()
+            terminal_state = sync_state.read_for_graph(cfg.context_graph_id)
 
         if failure is not None:
             raise failure
@@ -795,6 +799,8 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     baseline_catchup_job_id = ""
     fresh_catchup_seen = False
     fresh_catchup_job_id = ""
+    catchup_retry_attempts = 0
+    next_catchup_retry_at = 0.0
     authoritative_attempted = False
     authoritative_recovered = False
     authoritative_complete = False
@@ -802,7 +808,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     sync_complete = False
     last_join_attempt = float("-inf")
     deadline = time.monotonic() + max(1, int(getattr(args, "timeout", 180) or 180))
-    track_sync = bool(managed_graph and getattr(args, "wait", False))
+    track_sync = bool(getattr(args, "wait", False))
 
     if (
         release_graph
@@ -814,7 +820,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         return 2
 
     if track_sync:
-        known_public, known_community = _last_sync_counts()
+        known_public, known_community = _last_sync_counts(cfg.context_graph_id)
         sync_state.write(
             "running",
             context_graph_id=cfg.context_graph_id,
@@ -993,9 +999,14 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         catchup_state = ""
         catchup_includes_swm = False
         catchup_job_id = ""
+        exact_job_status = False
         if getattr(args, "wait", False) and subscribed:
             try:
-                catchup = client.catchup_status(cfg.context_graph_id)
+                catchup, exact_job_status = _catchup_status(
+                    client,
+                    cfg.context_graph_id,
+                    fresh_catchup_job_id,
+                )
                 last_catchup = catchup
                 catchup_state = str(catchup.get("status") or "").lower()
                 catchup_includes_swm = catchup.get("includeSharedMemory") is True
@@ -1005,15 +1016,43 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                     or catchup_job_id != baseline_catchup_job_id
                 ):
                     fresh_catchup_seen = True
-                    if not fresh_catchup_job_id:
+                    if not fresh_catchup_job_id or not exact_job_status:
                         fresh_catchup_job_id = catchup_job_id
                 if _catchup_denied(catchup):
                     pending_approval = True
                     admitted = False
             except DkgError:
                 pass
+        retryable_catchup = (
+            not authoritative_recovered
+            and getattr(args, "wait", False)
+            and subscribed
+            and (catchup_restarted or fresh_catchup_seen)
+            and catchup_state in {"deferred", "unreachable"}
+        )
+        if retryable_catchup and now >= next_catchup_retry_at and now < deadline:
+            catchup_retry_attempts += 1
+            next_catchup_retry_at = now + min(
+                10.0,
+                float(2 ** min(catchup_retry_attempts - 1, 3)),
+            )
+            try:
+                replacement = client.subscribe_context_graph(cfg.context_graph_id)
+                replacement_job_id = _catchup_job_id(replacement)
+                fresh_catchup_seen = True
+                fresh_catchup_job_id = replacement_job_id
+                last_catchup = replacement if isinstance(replacement, dict) else {}
+                print(
+                    "Retrying DKG catch-up after "
+                    f"{catchup_state} state (attempt {catchup_retry_attempts})."
+                )
+                continue
+            except DkgError as exc:
+                last_subscribe_error = str(exc)
         fresh_job_complete = catchup_state == "done" and (
-            not fresh_catchup_job_id or catchup_job_id == fresh_catchup_job_id
+            exact_job_status
+            or not fresh_catchup_job_id
+            or catchup_job_id == fresh_catchup_job_id
         )
         catchup_pending = not authoritative_recovered and (
             catchup_state in {"queued", "running"}
@@ -1217,7 +1256,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         time.sleep(min(3.0, max(0.2, deadline - now)))
 
     if track_sync:
-        current_transfer = sync_state.read()
+        current_transfer = sync_state.read_for_graph(cfg.context_graph_id)
         if sync_complete:
             sync_state.write(
                 "done",
@@ -1817,6 +1856,27 @@ def _catchup_job_id(catchup: Any) -> str:
     if isinstance(nested, dict):
         catchup = nested
     return str(catchup.get("jobId") or catchup.get("job_id") or catchup.get("id") or "")
+
+
+def _catchup_status(
+    client: DkgClient,
+    context_graph_id: str,
+    job_id: str = "",
+) -> tuple[Dict[str, Any], bool]:
+    """Read an exact catch-up job when supported, otherwise the graph latest."""
+    if job_id:
+        try:
+            return client.catchup_status(context_graph_id, job_id=job_id), True
+        except TypeError as exc:
+            # Compatibility for older plugin clients and test doubles that do
+            # not yet accept the keyword. Do not hide unrelated TypeErrors.
+            if "job_id" not in str(exc):
+                raise
+        except DkgError:
+            # The daemon bounds its job history. If the exact job was evicted,
+            # inspect the latest job and adopt it in the caller.
+            pass
+    return client.catchup_status(context_graph_id), False
 
 
 def _should_request_private_join(cfg: BlackboxConfig) -> bool:

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -799,6 +799,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     baseline_catchup_job_id = ""
     fresh_catchup_seen = False
     fresh_catchup_job_id = ""
+    refreshed_catchup_job_id = ""
     catchup_retry_attempts = 0
     next_catchup_retry_at = 0.0
     authoritative_attempted = False
@@ -943,7 +944,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             # pass settled, do not launch a competing full-store query merely
             # to decide whether to persist the background subscription.
             rs = (
-                ruleset.refresh(cfg, client)
+                ruleset.refresh(cfg, client, force_query=True)
                 if authoritative_recovered
                 else ruleset.peek(cfg)
             )
@@ -1076,7 +1077,16 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 # job status until the transfer reaches a terminal state.
                 rs = ruleset.peek(cfg)
             else:
-                rs = ruleset.refresh(cfg, client)
+                barrier_job_id = (
+                    catchup_job_id or fresh_catchup_job_id or "<unscoped>"
+                )
+                force_query = (
+                    fresh_job_complete
+                    and barrier_job_id != refreshed_catchup_job_id
+                )
+                rs = ruleset.refresh(cfg, client, force_query=force_query)
+                if force_query:
+                    refreshed_catchup_job_id = barrier_job_id
         counts = rs.counts()
         public_count = _ruleset_graph_count(rs, "public")
         community_count = _ruleset_graph_count(rs, "community")
@@ -1149,7 +1159,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 deadline,
                 on_progress=_record_verified_pass,
             )
-            rs = ruleset.refresh(cfg, client)
+            rs = ruleset.refresh(cfg, client, force_query=True)
             counts = rs.counts()
             public_count = max(public_count, _ruleset_graph_count(rs, "public"))
             community_count = _ruleset_graph_count(rs, "community")
@@ -1354,7 +1364,12 @@ def _catchup_authoritative_vm(
     heartbeat_seconds = 10.0
 
     try:
-        _connect_verifiable_source(client, graph_peer_id, deadline)
+        _connect_verifiable_source(
+            client,
+            context_graph_id,
+            graph_peer_id,
+            deadline,
+        )
     except DkgError as exc:
         error = f"verifiable graph source is unreachable: {exc}"
         sync_state.write(
@@ -1788,6 +1803,7 @@ def _configured_publisher_circuits(client: DkgClient, peer_id: str) -> List[str]
 
 def _connect_verifiable_source(
     client: DkgClient,
+    context_graph_id: str,
     graph_peer_id: str,
     deadline: float,
 ) -> None:
@@ -1824,6 +1840,7 @@ def _connect_verifiable_source(
             break
         sync_state.write(
             "running",
+            context_graph_id=context_graph_id,
             graph_peer_id=graph_peer_id,
             phase="discovering-verifiable-source",
         )

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -1872,10 +1872,12 @@ def _catchup_status(
             # not yet accept the keyword. Do not hide unrelated TypeErrors.
             if "job_id" not in str(exc):
                 raise
-        except DkgError:
+        except DkgError as exc:
             # The daemon bounds its job history. If the exact job was evicted,
-            # inspect the latest job and adopt it in the caller.
-            pass
+            # inspect the latest job and adopt it in the caller. Transport and
+            # server failures must keep the caller pinned to this exact job.
+            if exc.status_code not in {404, 410}:
+                raise
     return client.catchup_status(context_graph_id), False
 
 

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -947,7 +947,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             if authoritative_recovered:
                 try:
                     rs = ruleset.refresh(cfg, client, force_query=True)
-                except ruleset.RulesetRefreshLockUnavailable:
+                except ruleset.RulesetRefreshUnavailable:
                     rs = ruleset.peek(cfg)
                 else:
                     authoritative_cache_refreshed = True
@@ -1096,7 +1096,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 force_query = force_catchup_query or force_authoritative_query
                 try:
                     rs = ruleset.refresh(cfg, client, force_query=force_query)
-                except ruleset.RulesetRefreshLockUnavailable:
+                except ruleset.RulesetRefreshUnavailable:
                     rs = ruleset.peek(cfg)
                 else:
                     if force_catchup_query:
@@ -1185,7 +1185,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             if authoritative_recovered:
                 try:
                     rs = ruleset.refresh(cfg, client, force_query=True)
-                except ruleset.RulesetRefreshLockUnavailable:
+                except ruleset.RulesetRefreshUnavailable:
                     rs = ruleset.peek(cfg)
                 else:
                     authoritative_cache_refreshed = True

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -462,9 +462,15 @@ def _cmd_sync(args: argparse.Namespace) -> int:
     """Run a ruleset sync, translating an interactive cancellation cleanly."""
     try:
         cfg = load_blackbox_config()
-        if not _uses_managed_dkg(cfg, args):
-            return _cmd_sync_impl(args)
-        return _cmd_sync_with_managed_dkg(cfg, args)
+        if _uses_managed_dkg(cfg, args):
+            return _cmd_sync_with_managed_dkg(cfg, args)
+        if getattr(args, "wait", False):
+            with _managed_sync_lock() as acquired:
+                if not acquired:
+                    print("Blackbox sync is already running; no second transfer was queued.")
+                    return 0
+                return _cmd_sync_impl(args)
+        return _cmd_sync_impl(args)
     except KeyboardInterrupt:
         try:
             current_transfer = sync_state.read()
@@ -788,6 +794,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     baseline_catchup_known = False
     baseline_catchup_job_id = ""
     fresh_catchup_seen = False
+    fresh_catchup_job_id = ""
     authoritative_attempted = False
     authoritative_recovered = False
     authoritative_complete = False
@@ -824,7 +831,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     except (DkgError, AttributeError):
         pass
 
-    if managed_graph:
+    if getattr(args, "wait", False):
         try:
             baseline_catchup = client.catchup_status(cfg.context_graph_id)
             baseline_catchup_known = True
@@ -958,6 +965,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                     or subscription_job_id != baseline_catchup_job_id
                 ):
                     fresh_catchup_seen = True
+                    fresh_catchup_job_id = subscription_job_id
                 if not private_graph:
                     admitted = True
                     pending_approval = False
@@ -984,7 +992,8 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
 
         catchup_state = ""
         catchup_includes_swm = False
-        if managed_graph and subscribed:
+        catchup_job_id = ""
+        if getattr(args, "wait", False) and subscribed:
             try:
                 catchup = client.catchup_status(cfg.context_graph_id)
                 last_catchup = catchup
@@ -996,13 +1005,32 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                     or catchup_job_id != baseline_catchup_job_id
                 ):
                     fresh_catchup_seen = True
+                    if not fresh_catchup_job_id:
+                        fresh_catchup_job_id = catchup_job_id
                 if _catchup_denied(catchup):
                     pending_approval = True
                     admitted = False
             except DkgError:
                 pass
+        fresh_job_complete = catchup_state == "done" and (
+            not fresh_catchup_job_id or catchup_job_id == fresh_catchup_job_id
+        )
+        catchup_pending = not authoritative_recovered and (
+            catchup_state in {"queued", "running"}
+            or (
+                getattr(args, "wait", False)
+                and (catchup_restarted or fresh_catchup_seen)
+                and not fresh_job_complete
+                and catchup_state not in {"failed", "cancelled", "denied"}
+            )
+        )
+        catchup_failed = (
+            not authoritative_recovered
+            and (catchup_restarted or fresh_catchup_seen)
+            and catchup_state in {"failed", "cancelled", "denied"}
+        )
         if subscribed:
-            if catchup_state in {"queued", "running"}:
+            if catchup_pending or catchup_failed:
                 # DKG applies durable catch-up atomically. A full VM query here
                 # cannot expose useful partial rules and competes with the
                 # Blazegraph write that must finish first. Poll only the cheap
@@ -1055,13 +1083,11 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 not catchup_active
                 and (
                     not (catchup_restarted or fresh_catchup_seen)
-                    or catchup_state == "done"
+                    or fresh_job_complete
                 )
             )
         )
-        base_sync_complete = (
-            public_count > 0 if managed_graph else sum(counts.values()) > 0
-        ) and fresh_catchup_complete
+        base_sync_complete = public_count > 0 and fresh_catchup_complete
         # A clean local store has no public rows yet.  Waiting for
         # ``base_sync_complete`` before contacting the configured release
         # source deadlocks that exact first-sync case when generic peers do
@@ -1112,7 +1138,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                     "the required ruleset is unavailable."
                 )
                 break
-        subscription_ready = not managed_graph or subscribed
+        subscription_ready = subscribed
         sync_complete = (
             base_sync_complete
             and (not authoritative_attempted or authoritative_complete)
@@ -1149,7 +1175,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
 
         now = time.monotonic()
         if not getattr(args, "wait", False) or now >= deadline:
-            if managed_graph and not subscribed:
+            if not subscribed:
                 error = "required DKG subscription could not be persisted"
                 if last_subscribe_error:
                     error = f"{error}: {last_subscribe_error}"
@@ -1227,7 +1253,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 logger.debug("blackbox: subscribe pending: %s", last_subscribe_error)
             if _catchup_denied(last_catchup):
                 print("  DKG catch-up is denied until the curator confirms this node.")
-        elif release_graph and not subscribed:
+        elif not subscribed:
             print("  Required public VM subscription could not be persisted.")
             if last_subscribe_error:
                 print(f"  DKG subscription error: {last_subscribe_error}")

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -804,6 +804,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
     next_catchup_retry_at = 0.0
     authoritative_attempted = False
     authoritative_recovered = False
+    authoritative_cache_refreshed = False
     authoritative_complete = False
     authoritative_target = 0
     sync_complete = False
@@ -943,11 +944,15 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             # ``_record_verified_pass``. If the pinned source failed before a
             # pass settled, do not launch a competing full-store query merely
             # to decide whether to persist the background subscription.
-            rs = (
-                ruleset.refresh(cfg, client, force_query=True)
-                if authoritative_recovered
-                else ruleset.peek(cfg)
-            )
+            if authoritative_recovered:
+                try:
+                    rs = ruleset.refresh(cfg, client, force_query=True)
+                except ruleset.RulesetRefreshLockUnavailable:
+                    rs = ruleset.peek(cfg)
+                else:
+                    authoritative_cache_refreshed = True
+            else:
+                rs = ruleset.peek(cfg)
             counts = rs.counts()
             public_count = max(public_count, _ruleset_graph_count(rs, "public"))
             community_count = _ruleset_graph_count(rs, "community")
@@ -958,7 +963,9 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 # owns future updates and restart-safe reconciliation.
                 fresh_catchup_seen = True
                 authoritative_complete = (
-                    authoritative_target > 0 and public_count >= authoritative_target
+                    authoritative_cache_refreshed
+                    and authoritative_target > 0
+                    and public_count >= authoritative_target
                 )
 
         may_probe_private = private_graph and not getattr(args, "wait", False)
@@ -1055,6 +1062,7 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             or not fresh_catchup_job_id
             or catchup_job_id == fresh_catchup_job_id
         )
+        barrier_job_id = catchup_job_id or fresh_catchup_job_id or "<unscoped>"
         catchup_pending = not authoritative_recovered and (
             catchup_state in {"queued", "running"}
             or (
@@ -1077,16 +1085,24 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 # job status until the transfer reaches a terminal state.
                 rs = ruleset.peek(cfg)
             else:
-                barrier_job_id = (
-                    catchup_job_id or fresh_catchup_job_id or "<unscoped>"
-                )
-                force_query = (
+                force_catchup_query = (
                     fresh_job_complete
                     and barrier_job_id != refreshed_catchup_job_id
                 )
-                rs = ruleset.refresh(cfg, client, force_query=force_query)
-                if force_query:
-                    refreshed_catchup_job_id = barrier_job_id
+                force_authoritative_query = (
+                    authoritative_recovered
+                    and not authoritative_cache_refreshed
+                )
+                force_query = force_catchup_query or force_authoritative_query
+                try:
+                    rs = ruleset.refresh(cfg, client, force_query=force_query)
+                except ruleset.RulesetRefreshLockUnavailable:
+                    rs = ruleset.peek(cfg)
+                else:
+                    if force_catchup_query:
+                        refreshed_catchup_job_id = barrier_job_id
+                    if force_authoritative_query:
+                        authoritative_cache_refreshed = True
         counts = rs.counts()
         public_count = _ruleset_graph_count(rs, "public")
         community_count = _ruleset_graph_count(rs, "community")
@@ -1124,12 +1140,19 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
         # idempotent source-pinned recovery is: it has independently
         # verified the durable VM snapshot and may satisfy this gate on the
         # following loop iteration.
-        authoritative_fallback_ready = authoritative_recovered
+        authoritative_fallback_ready = (
+            authoritative_recovered and authoritative_cache_refreshed
+        )
         catchup_active = catchup_state in {"queued", "running"}
+        catchup_cache_refreshed = (
+            not fresh_job_complete
+            or refreshed_catchup_job_id == barrier_job_id
+        )
         fresh_catchup_complete = authoritative_fallback_ready or (
             not getattr(args, "wait", False)
             or (
                 not catchup_active
+                and catchup_cache_refreshed
                 and (
                     not (catchup_restarted or fresh_catchup_seen)
                     or fresh_job_complete
@@ -1159,7 +1182,15 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
                 deadline,
                 on_progress=_record_verified_pass,
             )
-            rs = ruleset.refresh(cfg, client, force_query=True)
+            if authoritative_recovered:
+                try:
+                    rs = ruleset.refresh(cfg, client, force_query=True)
+                except ruleset.RulesetRefreshLockUnavailable:
+                    rs = ruleset.peek(cfg)
+                else:
+                    authoritative_cache_refreshed = True
+            else:
+                rs = ruleset.refresh(cfg, client)
             counts = rs.counts()
             public_count = max(public_count, _ruleset_graph_count(rs, "public"))
             community_count = _ruleset_graph_count(rs, "community")
@@ -1168,7 +1199,9 @@ def _cmd_sync_impl(args: argparse.Namespace) -> int:
             authoritative_target = public_count
         if authoritative_recovered:
             authoritative_complete = (
-                authoritative_target > 0 and public_count >= authoritative_target
+                authoritative_cache_refreshed
+                and authoritative_target > 0
+                and public_count >= authoritative_target
             )
             if authoritative_target <= 0:
                 error = "authoritative VM returned no public threat entries"

--- a/plugins/blackbox/dashboard/server.py
+++ b/plugins/blackbox/dashboard/server.py
@@ -287,7 +287,7 @@ def _network_sync_once(
 def _sync_ruleset_once(load_config: Any, dkg_client_cls: Any, ruleset_mod: Any) -> Dict[str, int]:
     """Ensure one public-graph subscription and refresh curated VM rules."""
     cfg = load_config()
-    transfer = sync_state.read()
+    transfer = sync_state.read_for_graph(cfg.context_graph_id)
     if transfer.get("status") == "running":
         # A replacement snapshot is staged atomically. Keep serving the last
         # verified cache while it is received instead of replacing the UI and
@@ -1383,7 +1383,7 @@ def create_app(*, manage_blackbox: bool = False):
             "" if _is_hidden_swm_catchup_error(catchup_error) else node_catchup_state
         )
         catchup_state = node_catchup_state
-        authoritative_sync = sync_state.read()
+        authoritative_sync = sync_state.read_for_graph(cfg.context_graph_id)
         authoritative_running = authoritative_sync.get("status") == "running"
         authoritative_done = authoritative_sync.get("status") == "done"
         if authoritative_running:

--- a/plugins/blackbox/dkg_client.py
+++ b/plugins/blackbox/dkg_client.py
@@ -250,17 +250,27 @@ class DkgClient:
             include_shared_memory=include_shared_memory,
         )
 
-    def catchup_status(self, cg_id: str) -> Dict[str, Any]:
-        """Return the latest asynchronous catch-up job for ``cg_id``.
+    def catchup_status(
+        self,
+        cg_id: str,
+        *,
+        job_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return an asynchronous catch-up job for ``cg_id``.
 
         The daemon applies a recovered graph snapshot atomically, so consumers
         cannot count partial rows while it is running.  This status lets UI
         callers distinguish that active transfer from a genuinely empty graph.
+        Once subscribe returns a job id, pass it here so a concurrent newer job
+        cannot replace the status being awaited.
         """
-        encoded = urllib.parse.quote(cg_id, safe="")
+        if job_id:
+            query = f"jobId={urllib.parse.quote(job_id, safe='')}"
+        else:
+            query = f"contextGraphId={urllib.parse.quote(cg_id, safe='')}"
         return self._request(
             "GET",
-            f"/api/sync/catchup-status?contextGraphId={encoded}",
+            f"/api/sync/catchup-status?{query}",
         )
 
     def context_graphs(self) -> List[Dict[str, Any]]:

--- a/plugins/blackbox/dkg_client.py
+++ b/plugins/blackbox/dkg_client.py
@@ -36,6 +36,10 @@ Quad = Dict[str, str]
 class DkgError(RuntimeError):
     """Raised for any non-2xx daemon response or transport failure."""
 
+    def __init__(self, message: str, *, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
 
 def _validate_quads_literal_sizes(quads: List[Quad]) -> None:
     """Mirror DKG's writable-literal preflight before sending write payloads."""
@@ -156,7 +160,10 @@ class DkgClient:
                 raw = resp.read()
         except urllib.error.HTTPError as exc:
             detail = exc.read(1024).decode("utf-8", errors="replace")
-            raise DkgError(f"{method} {path} -> {exc.code}: {detail}") from exc
+            raise DkgError(
+                f"{method} {path} -> {exc.code}: {detail}",
+                status_code=exc.code,
+            ) from exc
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             raise DkgError(f"{method} {path} transport error: {exc}") from exc
         if not raw:

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -6,13 +6,14 @@ feature and is neither queried nor matched by the current release.
 
 It is cached to ``$BLACKBOX_HOME/ruleset.json`` and refreshed lazily:
 :func:`get` returns the cached ruleset immediately and, if the cache is older
-than ``sync_interval``, kicks off a single non-blocking background refresh
-(guarded by a file lock so only one refresher runs across processes). Every
-path fails open to the last-good (or empty) ruleset.
+than ``sync_interval``, kicks off a single non-blocking background refresh.
+Every refresh path shares a file lock so only one ruleset generation is built
+across processes. Every path fails open to the last-good (or empty) ruleset.
 """
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import json
 import logging
 import os
@@ -793,6 +794,7 @@ def _read_cache() -> Optional[Ruleset]:
 # ---------------------------------------------------------------------------
 
 _memory_lock = threading.Lock()
+_refresh_lock = threading.Lock()
 _memory_cache: Optional[Ruleset] = None
 _memory_cache_stamp: Optional[int] = None
 _refreshing = False
@@ -980,13 +982,111 @@ _EMPTY_RULESET_RETRY_S = 30.0
 _NONEMPTY_REFRESH_MIN_S = 15 * 60.0
 
 
-def refresh(config: Optional[BlackboxConfig] = None, client: Optional[DkgClient] = None) -> Ruleset:
+@contextmanager
+def _ruleset_refresh_lock(*, blocking: bool):
+    """Serialize expensive VM reads across threads and Blackbox processes."""
+    thread_acquired = _refresh_lock.acquire(blocking=blocking)
+    if not thread_acquired:
+        yield False
+        return
+
+    lock_fh = None
+    file_acquired = False
+    try:
+        try:
+            home = constants.blackbox_home()
+            home.mkdir(parents=True, exist_ok=True)
+            lock_fh = open(_lock_path(), "a+b")
+            if os.name == "nt":  # pragma: no cover - exercised on Windows
+                import msvcrt
+
+                if _lock_path().stat().st_size == 0:
+                    lock_fh.write(b"0")
+                    lock_fh.flush()
+                lock_fh.seek(0)
+                mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+                msvcrt.locking(lock_fh.fileno(), mode, 1)
+            else:
+                import fcntl
+
+                operation = fcntl.LOCK_EX
+                if not blocking:
+                    operation |= fcntl.LOCK_NB
+                fcntl.flock(lock_fh.fileno(), operation)
+            file_acquired = True
+        except BlockingIOError:
+            if lock_fh is not None:
+                lock_fh.close()
+                lock_fh = None
+            yield False
+            return
+        except OSError:
+            if not blocking and os.name == "nt":  # Windows lock contention
+                if lock_fh is not None:
+                    lock_fh.close()
+                    lock_fh = None
+                yield False
+                return
+            if lock_fh is not None:
+                lock_fh.close()
+                lock_fh = None
+        except Exception:
+            # Retain the in-process guard on platforms without a usable file
+            # lock. Ruleset refreshes are fail-open by design.
+            if lock_fh is not None:
+                lock_fh.close()
+                lock_fh = None
+
+        yield True
+    finally:
+        if lock_fh is not None:
+            try:
+                if file_acquired:
+                    if os.name == "nt":  # pragma: no cover - exercised on Windows
+                        import msvcrt
+
+                        lock_fh.seek(0)
+                        msvcrt.locking(lock_fh.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            finally:
+                lock_fh.close()
+        _refresh_lock.release()
+
+
+def refresh(
+    config: Optional[BlackboxConfig] = None,
+    client: Optional[DkgClient] = None,
+    *,
+    wait_for_lock: bool = True,
+) -> Ruleset:
     """Query the node, rebuild the ruleset, and persist it. Fail-open.
 
     Reads only the verified public graph (VM), fully paginated (no cap). If its
     query fails, the last-good public rules are preserved. On total
     failure, returns the last-good cache or an empty ruleset — never raises.
     """
+    initial_stamp = _cache_file_stamp()
+    with _ruleset_refresh_lock(blocking=wait_for_lock) as acquired:
+        if not acquired:
+            return _latest_cached_ruleset() or Ruleset()
+        # If another process completed while this caller waited, its atomic
+        # replacement is the requested fresh generation. Reuse it instead of
+        # immediately issuing the same large query sequence again.
+        if _cache_file_stamp() != initial_stamp:
+            latest = _latest_cached_ruleset()
+            if latest is not None:
+                return latest
+        return _refresh_unlocked(config, client)
+
+
+def _refresh_unlocked(
+    config: Optional[BlackboxConfig] = None,
+    client: Optional[DkgClient] = None,
+) -> Ruleset:
+    """Refresh while the caller holds :func:`_ruleset_refresh_lock`."""
     global _memory_cache, _memory_cache_stamp
     config = config or load_blackbox_config()
     client = client or DkgClient(url=config.dkg_url, dkg_home=config.dkg_home)
@@ -1083,33 +1183,12 @@ def _restore_tiers(rs: Ruleset, prior: Ruleset, tiers: List[str]) -> None:
 
 def _background_refresh(config: BlackboxConfig) -> None:
     global _refreshing
-    # Cross-process single-refresher guard via an exclusive lock file.
-    lock_fh = None
     try:
-        import fcntl
-
-        home = constants.blackbox_home()
-        home.mkdir(parents=True, exist_ok=True)
-        lock_fh = open(_lock_path(), "w", encoding="utf-8")
-        try:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except (OSError, BlockingIOError):
-            lock_fh.close()
-            _refreshing = False  # release the in-process guard for the next attempt
-            return  # another process is already refreshing
-    except Exception:
-        lock_fh = None  # platform without fcntl — fall back to in-process guard only
-    try:
-        refresh(config)
+        refresh(config, wait_for_lock=False)
     except Exception as exc:  # pragma: no cover - fail open
         logger.debug("blackbox: background refresh failed: %s", exc)
     finally:
         _refreshing = False
-        if lock_fh is not None:
-            try:
-                lock_fh.close()
-            except Exception:
-                pass
 
 
 def get(config: Optional[BlackboxConfig] = None) -> Ruleset:

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -14,6 +14,7 @@ across processes. Every path fails open to the last-good (or empty) ruleset.
 from __future__ import annotations
 
 from contextlib import contextmanager
+import errno
 import json
 import logging
 import os
@@ -382,6 +383,7 @@ class Ruleset:
     ioc: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     graph_threats: List[Dict[str, Any]] = field(default_factory=list)
     synced_at: float = 0.0
+    context_graph_id: str = ""
     _graph_entries_cache: Dict[str, List[Dict[str, Any]]] = field(
         default_factory=dict,
         init=False,
@@ -734,6 +736,7 @@ def _lock_path() -> Path:
 def _serialize(rs: Ruleset) -> Dict[str, Any]:
     return {
         "synced_at": rs.synced_at,
+        "context_graph_id": rs.context_graph_id,
         "injection": [
             {k: v for k, v in rule.items() if k != "pattern"} for rule in rs.injection
         ],
@@ -747,7 +750,10 @@ def _serialize(rs: Ruleset) -> Dict[str, Any]:
 
 
 def _deserialize(data: Dict[str, Any]) -> Ruleset:
-    rs = Ruleset(synced_at=float(data.get("synced_at", 0.0)))
+    rs = Ruleset(
+        synced_at=float(data.get("synced_at", 0.0)),
+        context_graph_id=str(data.get("context_graph_id") or ""),
+    )
     for rule in data.get("injection", []):
         src = _normalize_injection_pattern(str(rule.get("pattern_src") or ""))
         if not src:
@@ -810,14 +816,31 @@ def _cache_file_stamp() -> Optional[int]:
         return None
 
 
-def _latest_cached_ruleset() -> Optional[Ruleset]:
-    """Return memory cache, reloading when another process replaced the file."""
+def _matches_context_graph(rs: Optional[Ruleset], context_graph_id: str) -> bool:
+    """Return whether a cache generation belongs to the requested graph.
+
+    Cache files written before graph identity was persisted are accepted only
+    for the built-in release graph. They cannot safely be attributed to an
+    explicitly configured custom graph.
+    """
+    if rs is None:
+        return False
+    cached_graph = str(rs.context_graph_id or "")
+    if cached_graph:
+        return cached_graph == context_graph_id
+    return context_graph_id == constants.DEFAULT_CONTEXT_GRAPH_ID
+
+
+def _latest_cached_ruleset(context_graph_id: str = "") -> Optional[Ruleset]:
+    """Return the matching memory/disk generation, reloading replacements."""
     global _memory_cache, _memory_cache_stamp
     stamp = _cache_file_stamp()
     with _memory_lock:
         cached = _memory_cache
         known_stamp = _memory_cache_stamp
     if cached is not None and stamp == known_stamp:
+        if context_graph_id and not _matches_context_graph(cached, context_graph_id):
+            return None
         return cached
     disk = _read_cache()
     with _memory_lock:
@@ -825,6 +848,8 @@ def _latest_cached_ruleset() -> Optional[Ruleset]:
             _memory_cache = disk
             cached = disk
         _memory_cache_stamp = stamp
+    if context_graph_id and not _matches_context_graph(cached, context_graph_id):
+        return None
     return cached
 
 
@@ -997,15 +1022,16 @@ def _ruleset_refresh_lock(*, blocking: bool):
             home = constants.blackbox_home()
             home.mkdir(parents=True, exist_ok=True)
             lock_fh = open(_lock_path(), "a+b")
-            if os.name == "nt":  # pragma: no cover - exercised on Windows
-                import msvcrt
-
+            if os.name == "nt":  # pragma: no cover - exercised via helper
                 if _lock_path().stat().st_size == 0:
                     lock_fh.write(b"0")
                     lock_fh.flush()
                 lock_fh.seek(0)
-                mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
-                msvcrt.locking(lock_fh.fileno(), mode, 1)
+                if not _acquire_windows_file_lock(lock_fh, blocking=blocking):
+                    lock_fh.close()
+                    lock_fh = None
+                    yield False
+                    return
             else:
                 import fcntl
 
@@ -1021,7 +1047,7 @@ def _ruleset_refresh_lock(*, blocking: bool):
             yield False
             return
         except OSError:
-            if not blocking and os.name == "nt":  # Windows lock contention
+            if os.name == "nt":
                 if lock_fh is not None:
                     lock_fh.close()
                     lock_fh = None
@@ -1031,11 +1057,14 @@ def _ruleset_refresh_lock(*, blocking: bool):
                 lock_fh.close()
                 lock_fh = None
         except Exception:
-            # Retain the in-process guard on platforms without a usable file
-            # lock. Ruleset refreshes are fail-open by design.
             if lock_fh is not None:
                 lock_fh.close()
                 lock_fh = None
+            if os.name == "nt":
+                yield False
+                return
+            # Retain the in-process guard on platforms without a usable file
+            # lock. Ruleset refreshes are fail-open by design.
 
         yield True
     finally:
@@ -1056,6 +1085,34 @@ def _ruleset_refresh_lock(*, blocking: bool):
         _refresh_lock.release()
 
 
+def _acquire_windows_file_lock(
+    lock_fh: Any,
+    *,
+    blocking: bool,
+    msvcrt_module: Any = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> bool:
+    """Acquire one Windows byte lock without mistaking contention for success."""
+    if msvcrt_module is None:  # pragma: no cover - imported only on Windows
+        import msvcrt as msvcrt_module
+
+    while True:
+        lock_fh.seek(0)
+        try:
+            msvcrt_module.locking(
+                lock_fh.fileno(),
+                msvcrt_module.LK_NBLCK,
+                1,
+            )
+            return True
+        except OSError as exc:
+            if not blocking:
+                return False
+            if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                return False
+            sleep(0.05)
+
+
 def refresh(
     config: Optional[BlackboxConfig] = None,
     client: Optional[DkgClient] = None,
@@ -1068,15 +1125,19 @@ def refresh(
     query fails, the last-good public rules are preserved. On total
     failure, returns the last-good cache or an empty ruleset — never raises.
     """
+    config = config or load_blackbox_config()
+    context_graph_id = config.context_graph_id
     initial_stamp = _cache_file_stamp()
     with _ruleset_refresh_lock(blocking=wait_for_lock) as acquired:
         if not acquired:
-            return _latest_cached_ruleset() or Ruleset()
+            return _latest_cached_ruleset(context_graph_id) or Ruleset(
+                context_graph_id=context_graph_id
+            )
         # If another process completed while this caller waited, its atomic
         # replacement is the requested fresh generation. Reuse it instead of
         # immediately issuing the same large query sequence again.
         if _cache_file_stamp() != initial_stamp:
-            latest = _latest_cached_ruleset()
+            latest = _latest_cached_ruleset(context_graph_id)
             if latest is not None:
                 return latest
         return _refresh_unlocked(config, client)
@@ -1089,6 +1150,7 @@ def _refresh_unlocked(
     """Refresh while the caller holds :func:`_ruleset_refresh_lock`."""
     global _memory_cache, _memory_cache_stamp
     config = config or load_blackbox_config()
+    context_graph_id = config.context_graph_id
     client = client or DkgClient(url=config.dkg_url, dkg_home=config.dkg_home)
     tiers = ((constants.VIEW_VERIFIABLE_MEMORY, "public"),)
     fetched = {tier: _fetch_tier(client, config.context_graph_id, view) for view, tier in tiers}
@@ -1103,9 +1165,14 @@ def _refresh_unlocked(
         # transient empty query (or a concurrent refresh racing catch-up)
         # must never erase an already verified, enforceable ruleset.
         disk_prior = _read_cache()
-        candidates = [item for item in (_memory_cache, disk_prior) if item is not None]
+        candidates = [
+            item
+            for item in (_memory_cache, disk_prior)
+            if _matches_context_graph(item, context_graph_id)
+        ]
         prior = max(candidates, key=lambda item: item.source_count("public"), default=None)
         if prior is not None and prior.source_count("public") > 0:
+            prior.context_graph_id = context_graph_id
             prior.synced_at = time.time()
             _write_cache(prior)
             with _memory_lock:
@@ -1115,8 +1182,9 @@ def _refresh_unlocked(
 
     if all(rows is None for rows in fetched.values()):
         # Every tier failed — keep the last-good ruleset instead of emptying.
-        existing = _latest_cached_ruleset()
+        existing = _latest_cached_ruleset(context_graph_id)
         if existing is not None:
+            existing.context_graph_id = context_graph_id
             existing.synced_at = time.time()
             _write_cache(existing)
             with _memory_lock:
@@ -1130,6 +1198,7 @@ def _refresh_unlocked(
             continue
         rows.extend((row, tier) for row in view_rows)
     rs = build_from_rows(rows)
+    rs.context_graph_id = context_graph_id
     if empty_success:
         # A fresh node's subscribe/catch-up is async. Do not cache "0 rules" as
         # fresh for the full sync interval; retry soon so the dashboard updates
@@ -1140,7 +1209,7 @@ def _refresh_unlocked(
 
     errored = [tier for tier, view_rows in fetched.items() if view_rows is None]
     if errored:
-        prior = _latest_cached_ruleset()
+        prior = _latest_cached_ruleset(context_graph_id)
         if prior is not None:
             _restore_tiers(rs, prior, errored)
 
@@ -1199,9 +1268,14 @@ def get(config: Optional[BlackboxConfig] = None) -> Ruleset:
     """
     global _memory_cache, _memory_cache_stamp, _refreshing
     config = config or load_blackbox_config()
-    cached = _latest_cached_ruleset()
+    cached = _latest_cached_ruleset(config.context_graph_id)
     if cached is None:
-        cached = _read_cache() or Ruleset()
+        disk = _read_cache()
+        cached = (
+            disk
+            if _matches_context_graph(disk, config.context_graph_id)
+            else Ruleset(context_graph_id=config.context_graph_id)
+        )
         with _memory_lock:
             _memory_cache = cached
             _memory_cache_stamp = _cache_file_stamp()
@@ -1235,14 +1309,15 @@ def peek(config: Optional[BlackboxConfig] = None) -> Ruleset:
     """
     global _memory_cache, _memory_cache_stamp
     config = config or load_blackbox_config()
-    del config  # Kept for API symmetry and future profile-aware caches.
-    cached = _latest_cached_ruleset()
+    cached = _latest_cached_ruleset(config.context_graph_id)
     if cached is None:
-        cached = _read_cache() or Ruleset()
+        disk = _read_cache()
+        cached = (
+            disk
+            if _matches_context_graph(disk, config.context_graph_id)
+            else Ruleset(context_graph_id=config.context_graph_id)
+        )
         with _memory_lock:
-            if _memory_cache is None:
-                _memory_cache = cached
-                _memory_cache_stamp = _cache_file_stamp()
-            else:
-                cached = _memory_cache
+            _memory_cache = cached
+            _memory_cache_stamp = _cache_file_stamp()
     return cached

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -1021,7 +1021,7 @@ def _ruleset_refresh_lock(*, blocking: bool):
         try:
             home = constants.blackbox_home()
             home.mkdir(parents=True, exist_ok=True)
-            lock_fh = open(_lock_path(), "a+b")
+            lock_fh = open(_lock_path(), "a+b")  # windows-footgun: ok - binary byte lock
             if os.name == "nt":  # pragma: no cover - exercised via helper
                 if _lock_path().stat().st_size == 0:
                     lock_fh.write(b"0")

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -1009,6 +1009,10 @@ _WINDOWS_FILE_LOCK_TIMEOUT_S = 30.0
 _WINDOWS_FILE_LOCK_POLL_S = 0.05
 
 
+class RulesetRefreshLockUnavailable(RuntimeError):
+    """A required post-barrier refresh could not acquire its process lock."""
+
+
 def _is_windows_platform() -> bool:
     return os.name == "nt"
 
@@ -1136,7 +1140,9 @@ def refresh(
 
     Reads only the verified public graph (VM), fully paginated (no cap). If its
     query fails, the last-good public rules are preserved. On total
-    failure, returns the last-good cache or an empty ruleset — never raises.
+    failure, returns the last-good cache or an empty ruleset. ``force_query``
+    raises :class:`RulesetRefreshLockUnavailable` if its serialization lock
+    cannot be acquired, allowing completion-barrier callers to fail closed.
     ``force_query`` is reserved for callers that have crossed a DKG completion
     barrier and must not adopt a generation started before that barrier.
     """
@@ -1145,6 +1151,10 @@ def refresh(
     initial_stamp = _cache_file_stamp()
     with _ruleset_refresh_lock(blocking=wait_for_lock) as acquired:
         if not acquired:
+            if force_query:
+                raise RulesetRefreshLockUnavailable(
+                    "post-barrier ruleset refresh lock is unavailable"
+                )
             return _latest_cached_ruleset(context_graph_id) or Ruleset(
                 context_graph_id=context_graph_id
             )

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -1005,6 +1005,12 @@ def _dedupe_threat_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 _EMPTY_RULESET_RETRY_S = 30.0
 _NONEMPTY_REFRESH_MIN_S = 15 * 60.0
+_WINDOWS_FILE_LOCK_TIMEOUT_S = 30.0
+_WINDOWS_FILE_LOCK_POLL_S = 0.05
+
+
+def _is_windows_platform() -> bool:
+    return os.name == "nt"
 
 
 @contextmanager
@@ -1022,7 +1028,7 @@ def _ruleset_refresh_lock(*, blocking: bool):
             home = constants.blackbox_home()
             home.mkdir(parents=True, exist_ok=True)
             lock_fh = open(_lock_path(), "a+b")  # windows-footgun: ok - binary byte lock
-            if os.name == "nt":  # pragma: no cover - exercised via helper
+            if _is_windows_platform():  # pragma: no cover - exercised via helper
                 if _lock_path().stat().st_size == 0:
                     lock_fh.write(b"0")
                     lock_fh.flush()
@@ -1047,7 +1053,7 @@ def _ruleset_refresh_lock(*, blocking: bool):
             yield False
             return
         except OSError:
-            if os.name == "nt":
+            if _is_windows_platform():
                 if lock_fh is not None:
                     lock_fh.close()
                     lock_fh = None
@@ -1060,7 +1066,7 @@ def _ruleset_refresh_lock(*, blocking: bool):
             if lock_fh is not None:
                 lock_fh.close()
                 lock_fh = None
-            if os.name == "nt":
+            if _is_windows_platform():
                 yield False
                 return
             # Retain the in-process guard on platforms without a usable file
@@ -1071,7 +1077,7 @@ def _ruleset_refresh_lock(*, blocking: bool):
         if lock_fh is not None:
             try:
                 if file_acquired:
-                    if os.name == "nt":  # pragma: no cover - exercised on Windows
+                    if _is_windows_platform():  # pragma: no cover - exercised on Windows
                         import msvcrt
 
                         lock_fh.seek(0)
@@ -1090,12 +1096,15 @@ def _acquire_windows_file_lock(
     *,
     blocking: bool,
     msvcrt_module: Any = None,
+    timeout_s: float = _WINDOWS_FILE_LOCK_TIMEOUT_S,
+    monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
 ) -> bool:
-    """Acquire one Windows byte lock without mistaking contention for success."""
+    """Acquire one Windows byte lock within a bounded contention window."""
     if msvcrt_module is None:  # pragma: no cover - imported only on Windows
         import msvcrt as msvcrt_module
 
+    deadline = monotonic() + max(0.0, timeout_s)
     while True:
         lock_fh.seek(0)
         try:
@@ -1110,7 +1119,10 @@ def _acquire_windows_file_lock(
                 return False
             if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
                 return False
-            sleep(0.05)
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return False
+            sleep(min(_WINDOWS_FILE_LOCK_POLL_S, remaining))
 
 
 def refresh(

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -1009,8 +1009,16 @@ _WINDOWS_FILE_LOCK_TIMEOUT_S = 30.0
 _WINDOWS_FILE_LOCK_POLL_S = 0.05
 
 
-class RulesetRefreshLockUnavailable(RuntimeError):
+class RulesetRefreshUnavailable(RuntimeError):
+    """A required post-barrier refresh did not produce a fresh snapshot."""
+
+
+class RulesetRefreshLockUnavailable(RulesetRefreshUnavailable):
     """A required post-barrier refresh could not acquire its process lock."""
+
+
+class RulesetRefreshIncomplete(RulesetRefreshUnavailable):
+    """A required post-barrier refresh could not read a complete VM snapshot."""
 
 
 def _is_windows_platform() -> bool:
@@ -1141,10 +1149,11 @@ def refresh(
     Reads only the verified public graph (VM), fully paginated (no cap). If its
     query fails, the last-good public rules are preserved. On total
     failure, returns the last-good cache or an empty ruleset. ``force_query``
-    raises :class:`RulesetRefreshLockUnavailable` if its serialization lock
-    cannot be acquired, allowing completion-barrier callers to fail closed.
-    ``force_query`` is reserved for callers that have crossed a DKG completion
-    barrier and must not adopt a generation started before that barrier.
+    raises :class:`RulesetRefreshUnavailable` unless it can acquire the
+    serialization lock and read a non-empty VM snapshot, allowing
+    completion-barrier callers to fail closed. ``force_query`` is reserved for
+    callers that have crossed a DKG completion barrier and must not adopt a
+    generation started before that barrier.
     """
     config = config or load_blackbox_config()
     context_graph_id = config.context_graph_id
@@ -1165,12 +1174,14 @@ def refresh(
             latest = _latest_cached_ruleset(context_graph_id)
             if latest is not None:
                 return latest
-        return _refresh_unlocked(config, client)
+        return _refresh_unlocked(config, client, require_complete=force_query)
 
 
 def _refresh_unlocked(
     config: Optional[BlackboxConfig] = None,
     client: Optional[DkgClient] = None,
+    *,
+    require_complete: bool = False,
 ) -> Ruleset:
     """Refresh while the caller holds :func:`_ruleset_refresh_lock`."""
     global _memory_cache, _memory_cache_stamp
@@ -1184,6 +1195,18 @@ def _refresh_unlocked(
     # admission, and catch-up are DKG daemon responsibilities; a cache read must
     # never restart network recovery.
     empty_success = all(rows == [] for rows in fetched.values())
+    failed_tiers = [tier for tier, rows in fetched.items() if rows is None]
+
+    if require_complete:
+        if failed_tiers:
+            raise RulesetRefreshIncomplete(
+                "post-barrier VM query failed for "
+                + ", ".join(sorted(failed_tiers))
+            )
+        if empty_success:
+            raise RulesetRefreshIncomplete(
+                "post-barrier VM query returned an empty snapshot"
+            )
 
     if empty_success:
         # Snapshot replacement is atomic from the user's perspective. A
@@ -1232,7 +1255,7 @@ def _refresh_unlocked(
         retry_after = min(_EMPTY_RULESET_RETRY_S, interval)
         rs.synced_at = time.time() - interval + retry_after
 
-    errored = [tier for tier, view_rows in fetched.items() if view_rows is None]
+    errored = failed_tiers
     if errored:
         prior = _latest_cached_ruleset(context_graph_id)
         if prior is not None:

--- a/plugins/blackbox/ruleset.py
+++ b/plugins/blackbox/ruleset.py
@@ -1130,12 +1130,15 @@ def refresh(
     client: Optional[DkgClient] = None,
     *,
     wait_for_lock: bool = True,
+    force_query: bool = False,
 ) -> Ruleset:
     """Query the node, rebuild the ruleset, and persist it. Fail-open.
 
     Reads only the verified public graph (VM), fully paginated (no cap). If its
     query fails, the last-good public rules are preserved. On total
     failure, returns the last-good cache or an empty ruleset — never raises.
+    ``force_query`` is reserved for callers that have crossed a DKG completion
+    barrier and must not adopt a generation started before that barrier.
     """
     config = config or load_blackbox_config()
     context_graph_id = config.context_graph_id
@@ -1148,7 +1151,7 @@ def refresh(
         # If another process completed while this caller waited, its atomic
         # replacement is the requested fresh generation. Reuse it instead of
         # immediately issuing the same large query sequence again.
-        if _cache_file_stamp() != initial_stamp:
+        if not force_query and _cache_file_stamp() != initial_stamp:
             latest = _latest_cached_ruleset(context_graph_id)
             if latest is not None:
                 return latest

--- a/plugins/blackbox/sync_state.py
+++ b/plugins/blackbox/sync_state.py
@@ -35,6 +35,9 @@ def write(status: str, **details: Any) -> Dict[str, Any]:
     path.parent.mkdir(parents=True, exist_ok=True)
     now = time.time()
     previous = read()
+    context_graph_id = str(details.get("context_graph_id") or "")
+    if context_graph_id and str(previous.get("context_graph_id") or "") != context_graph_id:
+        previous = {}
     state = {
         "status": str(status),
         "started_at": previous.get("started_at", now),
@@ -68,4 +71,12 @@ def read() -> Dict[str, Any]:
             return {**state, "status": "failed", "error": "authoritative sync process exited"}
         if updated and time.time() - updated > _STALE_RUNNING_SECONDS:
             return {**state, "status": "failed", "error": "authoritative sync stopped updating"}
+    return state
+
+
+def read_for_graph(context_graph_id: str) -> Dict[str, Any]:
+    """Read transfer state only when it belongs to ``context_graph_id``."""
+    state = read()
+    if str(state.get("context_graph_id") or "") != str(context_graph_id or ""):
+        return {}
     return state

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -11,6 +11,9 @@ One test per confirmed finding so the fixes can't silently regress:
 ``HERMES_HOME``/``BLACKBOX_HOME`` are per-test tmpdirs (root conftest).
 """
 
+import errno
+import multiprocessing
+from pathlib import Path
 import re
 import threading
 import time
@@ -27,6 +30,16 @@ ruleset_mod = load_blackbox("ruleset")
 config_mod = load_blackbox("config")
 
 Ruleset = ruleset_mod.Ruleset
+
+
+def _hold_ruleset_file_lock(home, entered, release):
+    ruleset_mod.constants.blackbox_home = lambda: Path(home)
+    with ruleset_mod._ruleset_refresh_lock(blocking=True) as acquired:
+        if not acquired:
+            return
+        entered.set()
+        if release is not None:
+            release.wait(5)
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +204,115 @@ def test_concurrent_ruleset_refresh_reuses_completed_generation(monkeypatch, tmp
     assert len(calls) == 1
     assert len(results) == 2
     assert all(result.source_count("public") == 1 for result in results)
+
+
+def test_ruleset_cache_never_crosses_custom_context_graphs(monkeypatch, tmp_path):
+    row = {
+        "threat": "urn:defender:signal:graph-a",
+        "rdfType": "urn:defender:DependencySignal",
+        "packageEcosystem": "npm",
+        "packageName": "graph-a",
+        "packageVersion": "1.0.0",
+    }
+    monkeypatch.setattr(ruleset_mod.constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache", None)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache_stamp", None)
+    monkeypatch.setattr(ruleset_mod, "_fetch_tier", lambda *_args, **_kwargs: [row])
+
+    graph_a = config_mod.BlackboxConfig(context_graph_id="owner/graph-a")
+    graph_b = config_mod.BlackboxConfig(context_graph_id="owner/graph-b")
+    first = ruleset_mod.refresh(graph_a, object())
+    assert first.context_graph_id == "owner/graph-a"
+    assert first.source_count("public") == 1
+
+    monkeypatch.setattr(ruleset_mod, "_fetch_tier", lambda *_args, **_kwargs: [])
+    second = ruleset_mod.refresh(graph_b, object())
+
+    assert second.context_graph_id == "owner/graph-b"
+    assert second.source_count("public") == 0
+    assert ruleset_mod.peek(graph_b).source_count("public") == 0
+
+
+def test_legacy_unscoped_cache_is_not_valid_for_custom_graph(monkeypatch, tmp_path):
+    prior = Ruleset(
+        dependency={
+            "npm:legacy@1.0": {
+                "identifier": "dep:npm:legacy@1.0",
+                "source": "public",
+            }
+        }
+    )
+    monkeypatch.setattr(ruleset_mod.constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache", None)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache_stamp", None)
+    ruleset_mod._write_cache(prior)
+
+    custom = ruleset_mod.peek(
+        config_mod.BlackboxConfig(context_graph_id="owner/custom")
+    )
+    assert custom.context_graph_id == "owner/custom"
+    assert custom.source_count("public") == 0
+
+
+def test_ruleset_file_lock_serializes_processes(monkeypatch, tmp_path):
+    if "fork" not in multiprocessing.get_all_start_methods():
+        return
+    ctx = multiprocessing.get_context("fork")
+    first_entered = ctx.Event()
+    second_entered = ctx.Event()
+    release_first = ctx.Event()
+    first = ctx.Process(
+        target=_hold_ruleset_file_lock,
+        args=(str(tmp_path), first_entered, release_first),
+    )
+    second = ctx.Process(
+        target=_hold_ruleset_file_lock,
+        args=(str(tmp_path), second_entered, None),
+    )
+    first.start()
+    try:
+        assert first_entered.wait(5)
+        second.start()
+        assert not second_entered.wait(0.25)
+        release_first.set()
+        assert second_entered.wait(5)
+    finally:
+        release_first.set()
+        first.join(5)
+        if second.pid is not None:
+            second.join(5)
+        for process in (first, second):
+            if process.is_alive():
+                process.terminate()
+                process.join(5)
+    assert first.exitcode == 0
+    assert second.exitcode == 0
+
+
+def test_windows_blocking_lock_retries_until_acquired(tmp_path):
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+
+        def __init__(self):
+            self.attempts = 0
+
+        def locking(self, _fd, _mode, _size):
+            self.attempts += 1
+            if self.attempts < 3:
+                raise OSError(errno.EACCES, "lock violation")
+
+    fake = FakeMsvcrt()
+    sleeps = []
+    with (tmp_path / "ruleset.lock").open("a+b") as handle:
+        assert ruleset_mod._acquire_windows_file_lock(
+            handle,
+            blocking=True,
+            msvcrt_module=fake,
+            sleep=sleeps.append,
+        )
+
+    assert fake.attempts == 3
+    assert sleeps == [0.05, 0.05]
 
 
 def test_empty_initial_sync_retries_cache_without_network_orchestration(monkeypatch):

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -12,6 +12,8 @@ One test per confirmed finding so the fixes can't silently regress:
 """
 
 import re
+import threading
+import time
 
 from _blackbox_loader import load_blackbox
 
@@ -139,6 +141,56 @@ def test_ruleset_sync_is_uncapped(monkeypatch):
         kwargs["timeout"] == ruleset_mod._VM_PARTITION_QUERY_TIMEOUT
         for _query, kwargs in partition_queries
     )
+
+
+def test_concurrent_ruleset_refresh_reuses_completed_generation(monkeypatch, tmp_path):
+    started = threading.Event()
+    release = threading.Event()
+    second_started = threading.Event()
+    calls = []
+    results = []
+    row = {
+        "threat": "urn:defender:signal:serialized",
+        "rdfType": "urn:defender:DependencySignal",
+        "packageEcosystem": "npm",
+        "packageName": "serialized",
+        "packageVersion": "1.0.0",
+    }
+
+    def slow_fetch(*_args, **_kwargs):
+        calls.append(True)
+        started.set()
+        assert release.wait(5)
+        return [row]
+
+    monkeypatch.setattr(ruleset_mod.constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache", None)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache_stamp", None)
+    monkeypatch.setattr(ruleset_mod, "_fetch_tier", slow_fetch)
+
+    first = threading.Thread(
+        target=lambda: results.append(ruleset_mod.refresh(config_mod.BlackboxConfig(), object()))
+    )
+
+    def second_refresh():
+        second_started.set()
+        results.append(ruleset_mod.refresh(config_mod.BlackboxConfig(), object()))
+
+    second = threading.Thread(target=second_refresh)
+    first.start()
+    assert started.wait(5)
+    second.start()
+    assert second_started.wait(5)
+    time.sleep(0.05)
+    release.set()
+    first.join(5)
+    second.join(5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(calls) == 1
+    assert len(results) == 2
+    assert all(result.source_count("public") == 1 for result in results)
 
 
 def test_empty_initial_sync_retries_cache_without_network_orchestration(monkeypatch):

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -206,6 +206,77 @@ def test_concurrent_ruleset_refresh_reuses_completed_generation(monkeypatch, tmp
     assert all(result.source_count("public") == 1 for result in results)
 
 
+def test_post_barrier_refresh_does_not_reuse_pre_barrier_generation(
+    monkeypatch,
+    tmp_path,
+):
+    stale_query_started = threading.Event()
+    barrier_stamp_read = threading.Event()
+    release_stale_query = threading.Event()
+    results = {}
+    fetch_count = 0
+    real_cache_stamp = ruleset_mod._cache_file_stamp
+
+    def row(name):
+        return {
+            "threat": f"urn:defender:signal:{name}",
+            "rdfType": "urn:defender:DependencySignal",
+            "packageEcosystem": "npm",
+            "packageName": name,
+            "packageVersion": "1.0.0",
+        }
+
+    def staged_fetch(*_args, **_kwargs):
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            stale_query_started.set()
+            assert release_stale_query.wait(5)
+            return [row("stale")]
+        return [row("fresh")]
+
+    def observed_cache_stamp():
+        stamp = real_cache_stamp()
+        if threading.current_thread().name == "barrier-refresh":
+            barrier_stamp_read.set()
+        return stamp
+
+    cfg = config_mod.BlackboxConfig(context_graph_id="owner/public")
+    monkeypatch.setattr(ruleset_mod.constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache", None)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache_stamp", None)
+    monkeypatch.setattr(ruleset_mod, "_fetch_tier", staged_fetch)
+    monkeypatch.setattr(ruleset_mod, "_cache_file_stamp", observed_cache_stamp)
+
+    stale = threading.Thread(
+        name="pre-barrier-refresh",
+        target=lambda: results.setdefault(
+            "stale",
+            ruleset_mod.refresh(cfg, object()),
+        ),
+    )
+    barrier = threading.Thread(
+        name="barrier-refresh",
+        target=lambda: results.setdefault(
+            "fresh",
+            ruleset_mod.refresh(cfg, object(), force_query=True),
+        ),
+    )
+    stale.start()
+    assert stale_query_started.wait(5)
+    barrier.start()
+    assert barrier_stamp_read.wait(5)
+    release_stale_query.set()
+    stale.join(5)
+    barrier.join(5)
+
+    assert not stale.is_alive()
+    assert not barrier.is_alive()
+    assert fetch_count == 2
+    assert "npm:stale@1.0.0" in results["stale"].dependency
+    assert "npm:fresh@1.0.0" in results["fresh"].dependency
+
+
 def test_ruleset_cache_never_crosses_custom_context_graphs(monkeypatch, tmp_path):
     row = {
         "threat": "urn:defender:signal:graph-a",

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -315,6 +315,59 @@ def test_windows_blocking_lock_retries_until_acquired(tmp_path):
     assert sleeps == [0.05, 0.05]
 
 
+def test_windows_blocking_lock_times_out_under_contention(tmp_path):
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+
+        def __init__(self):
+            self.attempts = 0
+
+        def locking(self, _fd, _mode, _size):
+            self.attempts += 1
+            raise OSError(errno.EACCES, "lock violation")
+
+    fake = FakeMsvcrt()
+    clock = {"value": 10.0}
+    sleeps = []
+
+    def monotonic():
+        return clock["value"]
+
+    def sleep(seconds):
+        sleeps.append(seconds)
+        clock["value"] += seconds
+
+    with (tmp_path / "ruleset.lock").open("a+b") as handle:
+        assert not ruleset_mod._acquire_windows_file_lock(
+            handle,
+            blocking=True,
+            msvcrt_module=fake,
+            timeout_s=0.1,
+            monotonic=monotonic,
+            sleep=sleep,
+        )
+
+    assert fake.attempts == 3
+    assert len(sleeps) == 2
+    assert abs(sum(sleeps) - 0.1) < 1e-9
+
+
+def test_windows_ruleset_lock_does_not_claim_acquisition_after_timeout(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset_mod, "_is_windows_platform", lambda: True)
+    monkeypatch.setattr(
+        ruleset_mod,
+        "_acquire_windows_file_lock",
+        lambda *_args, **_kwargs: False,
+    )
+
+    with ruleset_mod._ruleset_refresh_lock(blocking=True) as acquired:
+        assert not acquired
+
+
 def test_empty_initial_sync_retries_cache_without_network_orchestration(monkeypatch):
     monkeypatch.setattr(ruleset_mod, "_write_cache", lambda rs: None)
     monkeypatch.setattr(ruleset_mod, "_memory_cache", None)

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -299,6 +299,48 @@ def test_forced_refresh_reports_lock_exhaustion(monkeypatch):
         )
 
 
+@pytest.mark.parametrize(
+    ("fresh_result", "error"),
+    [
+        (None, "failed for public"),
+        ([], "empty snapshot"),
+    ],
+)
+def test_forced_refresh_rejects_incomplete_vm_query_without_restamping_cache(
+    monkeypatch,
+    tmp_path,
+    fresh_result,
+    error,
+):
+    row = {
+        "threat": "urn:defender:signal:last-good",
+        "rdfType": "urn:defender:DependencySignal",
+        "packageEcosystem": "npm",
+        "packageName": "last-good",
+        "packageVersion": "1.0.0",
+    }
+    cfg = config_mod.BlackboxConfig(context_graph_id="owner/public")
+    monkeypatch.setattr(ruleset_mod.constants, "blackbox_home", lambda: tmp_path)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache", None)
+    monkeypatch.setattr(ruleset_mod, "_memory_cache_stamp", None)
+    monkeypatch.setattr(ruleset_mod, "_fetch_tier", lambda *_args, **_kwargs: [row])
+
+    prior = ruleset_mod.refresh(cfg, object())
+    cache_before = ruleset_mod._cache_path().read_bytes()
+
+    monkeypatch.setattr(
+        ruleset_mod,
+        "_fetch_tier",
+        lambda *_args, **_kwargs: fresh_result,
+    )
+    with pytest.raises(ruleset_mod.RulesetRefreshIncomplete, match=error):
+        ruleset_mod.refresh(cfg, object(), force_query=True)
+
+    assert ruleset_mod._cache_path().read_bytes() == cache_before
+    assert ruleset_mod.peek(cfg).synced_at == prior.synced_at
+    assert "npm:last-good@1.0.0" in ruleset_mod.peek(cfg).dependency
+
+
 def test_ruleset_cache_never_crosses_custom_context_graphs(monkeypatch, tmp_path):
     row = {
         "threat": "urn:defender:signal:graph-a",

--- a/tests/plugins/test_blackbox_audit_fixes.py
+++ b/tests/plugins/test_blackbox_audit_fixes.py
@@ -11,12 +11,15 @@ One test per confirmed finding so the fixes can't silently regress:
 ``HERMES_HOME``/``BLACKBOX_HOME`` are per-test tmpdirs (root conftest).
 """
 
+from contextlib import contextmanager
 import errno
 import multiprocessing
 from pathlib import Path
 import re
 import threading
 import time
+
+import pytest
 
 from _blackbox_loader import load_blackbox
 
@@ -275,6 +278,25 @@ def test_post_barrier_refresh_does_not_reuse_pre_barrier_generation(
     assert fetch_count == 2
     assert "npm:stale@1.0.0" in results["stale"].dependency
     assert "npm:fresh@1.0.0" in results["fresh"].dependency
+
+
+def test_forced_refresh_reports_lock_exhaustion(monkeypatch):
+    @contextmanager
+    def unavailable_lock(*, blocking):
+        assert blocking
+        yield False
+
+    monkeypatch.setattr(ruleset_mod, "_ruleset_refresh_lock", unavailable_lock)
+
+    with pytest.raises(
+        ruleset_mod.RulesetRefreshLockUnavailable,
+        match="post-barrier",
+    ):
+        ruleset_mod.refresh(
+            config_mod.BlackboxConfig(context_graph_id="owner/public"),
+            object(),
+            force_query=True,
+        )
 
 
 def test_ruleset_cache_never_crosses_custom_context_graphs(monkeypatch, tmp_path):

--- a/tests/plugins/test_blackbox_dashboard_server.py
+++ b/tests/plugins/test_blackbox_dashboard_server.py
@@ -218,6 +218,76 @@ def test_sync_state_rejects_abandoned_running_process(tmp_path, monkeypatch):
     assert state["error"] == "authoritative sync process exited"
 
 
+def test_sync_state_is_scoped_to_configured_context_graph(tmp_path, monkeypatch):
+    state_path = tmp_path / "authoritative-sync.json"
+    state_path.write_text(
+        '{"status":"done","context_graph_id":"owner/old"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sync_state, "_path", lambda: state_path)
+
+    assert sync_state.read_for_graph("owner/old")["status"] == "done"
+    assert sync_state.read_for_graph("owner/new") == {}
+
+
+def test_ruleset_sync_ignores_running_state_from_another_graph(monkeypatch):
+    cfg = SimpleNamespace(
+        context_graph_id="owner/new",
+        dkg_url="http://node",
+        dkg_home="/tmp/dkg",
+        sync_interval=3600,
+    )
+    refreshed = []
+
+    class Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        def catchup_status(self, _cg_id):
+            return {"jobId": "done", "status": "done"}
+
+    class Cached:
+        synced_at = 0.0
+
+        def counts(self):
+            return {
+                "injection": 0,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, _source):
+            return 0
+
+    class Ready(Cached):
+        def counts(self):
+            return {**super().counts(), "dependency": 2}
+
+        def graph_count(self, source):
+            return 2 if source == "public" else 0
+
+    rules = SimpleNamespace(
+        peek=lambda _cfg: Cached(),
+        refresh=lambda _cfg, _client: refreshed.append(True) or Ready(),
+    )
+    monkeypatch.setattr(
+        server.sync_state,
+        "read",
+        lambda: {
+            "status": "running",
+            "context_graph_id": "owner/old",
+            "public_entries": 999,
+        },
+    )
+
+    result = server._sync_ruleset_once(lambda: cfg, Client, rules)
+
+    assert refreshed == [True]
+    assert result["public"] == 2
+
+
 def test_graph_sync_state_treats_authoritatively_settled_zero_as_ready():
     assert server._graph_sync_state(0, True, "running", settled=True) == "ready"
 

--- a/tests/plugins/test_blackbox_dkg_client.py
+++ b/tests/plugins/test_blackbox_dkg_client.py
@@ -385,8 +385,9 @@ def test_write_path_raises_dkg_error_on_http_error(monkeypatch):
 
     monkeypatch.setattr(dkg_client.urllib.request, "urlopen", raise_http)
     client = dkg_client.DkgClient(url="http://node", token="t")
-    with pytest.raises(dkg_client.DkgError):
+    with pytest.raises(dkg_client.DkgError) as exc_info:
         client.share_knowledge_asset("cg", "n", [])
+    assert exc_info.value.status_code == 403
 
 
 def test_share_is_idempotent_on_already_finalized(monkeypatch):

--- a/tests/plugins/test_blackbox_dkg_client.py
+++ b/tests/plugins/test_blackbox_dkg_client.py
@@ -165,6 +165,19 @@ def test_catchup_status_encodes_context_graph_id(monkeypatch):
     )
 
 
+def test_catchup_status_can_pin_exact_job_id(monkeypatch):
+    cap = _capture(monkeypatch, '{"jobId":"fresh","status":"done"}')
+    client = dkg_client.DkgClient(url="http://node", token="tok")
+
+    result = client.catchup_status("owner/graph", job_id="fresh job/1")
+
+    assert result == {"jobId": "fresh", "status": "done"}
+    assert cap["method"] == "GET"
+    assert cap["url"] == (
+        "http://node/api/sync/catchup-status?jobId=fresh%20job%2F1"
+    )
+
+
 def test_connect_peer_uses_dkg_peer_resolution(monkeypatch):
     cap = _capture(monkeypatch)
     client = dkg_client.DkgClient(url="http://node", token="tok")

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -490,6 +490,80 @@ def test_custom_public_sync_polls_original_job_when_latest_changes(monkeypatch):
     assert status_jobs == [None, "fresh"]
 
 
+@pytest.mark.parametrize(
+    ("status_code", "message"),
+    [(None, "transport error: connection reset"), (500, "internal server error")],
+)
+def test_custom_public_sync_retries_exact_job_after_transient_status_error(
+    monkeypatch,
+    status_code,
+    message,
+):
+    status_jobs = []
+    exact_attempts = {"value": 0}
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, _cg_id):
+            return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+        def catchup_status(self, _cg_id, *, job_id=None):
+            status_jobs.append(job_id)
+            if job_id == "fresh":
+                exact_attempts["value"] += 1
+                if exact_attempts["value"] == 1:
+                    raise cli_mod.DkgError(message, status_code=status_code)
+                return {"jobId": "fresh", "status": "done"}
+            if len(status_jobs) == 1:
+                return {"jobId": "old", "status": "done"}
+            return {"jobId": "newer-unrelated", "status": "running"}
+
+    class FakeRuleset:
+        def counts(self):
+            return {
+                "injection": 1,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return 1 if source == "public" else 0
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
+    )
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: FakeRuleset())
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync(args) == 0
+    assert status_jobs == [None, "fresh", "fresh"]
+
+
+def test_catchup_status_adopts_latest_only_when_exact_job_is_missing():
+    status_jobs = []
+
+    class FakeClient:
+        def catchup_status(self, _cg_id, *, job_id=None):
+            status_jobs.append(job_id)
+            if job_id:
+                raise cli_mod.DkgError("job evicted", status_code=404)
+            return {"jobId": "replacement", "status": "running"}
+
+    status, exact = cli_mod._catchup_status(FakeClient(), "owner/custom", "evicted")
+
+    assert status == {"jobId": "replacement", "status": "running"}
+    assert not exact
+    assert status_jobs == ["evicted", None]
+
+
 def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypatch, capsys):
     refreshes = []
     events = []

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -352,6 +352,61 @@ def test_blackbox_sync_waits_for_custom_public_graph_catchup(monkeypatch):
     assert refreshes == [{"force_query": True}]
 
 
+def test_custom_public_sync_retries_forced_refresh_lock_contention(monkeypatch):
+    refreshes = []
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, _cg_id):
+            return {"catchup": {"jobId": "fresh", "status": "done"}}
+
+        def catchup_status(self, _cg_id, *, job_id=None):
+            if job_id:
+                return {"jobId": job_id, "status": "done"}
+            return {"jobId": "old", "status": "done"}
+
+    class FakeRuleset:
+        def __init__(self, public):
+            self.public = public
+
+        def counts(self):
+            return {
+                "injection": self.public,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return self.public if source == "public" else 0
+
+    def refresh(_cfg, _client, **kwargs):
+        refreshes.append(kwargs)
+        if len(refreshes) == 1:
+            raise ruleset_mod.RulesetRefreshLockUnavailable("busy")
+        return FakeRuleset(2)
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
+    )
+    monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: FakeRuleset(1))
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", refresh)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync_impl(args) == 0
+    assert refreshes == [
+        {"force_query": True},
+        {"force_query": True},
+    ]
+
+
 def test_blackbox_sync_wait_require_rules_fails_closed_when_busy(monkeypatch, capsys):
     class BusyLock:
         def __enter__(self):

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -407,6 +407,58 @@ def test_custom_public_sync_retries_forced_refresh_lock_contention(monkeypatch):
     ]
 
 
+def test_custom_public_sync_retries_incomplete_forced_query(monkeypatch):
+    refreshes = []
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, _cg_id):
+            return {"catchup": {"jobId": "fresh", "status": "done"}}
+
+        def catchup_status(self, _cg_id, *, job_id=None):
+            if job_id:
+                return {"jobId": job_id, "status": "done"}
+            return {"jobId": "old", "status": "done"}
+
+    class FakeRuleset:
+        def counts(self):
+            return {
+                "injection": 2,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return 2 if source == "public" else 0
+
+    def refresh(_cfg, _client, **kwargs):
+        refreshes.append(kwargs)
+        if len(refreshes) == 1:
+            raise ruleset_mod.RulesetRefreshIncomplete("empty snapshot")
+        return FakeRuleset()
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
+    )
+    monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: FakeRuleset())
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", refresh)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync_impl(args) == 0
+    assert refreshes == [
+        {"force_query": True},
+        {"force_query": True},
+    ]
+
+
 def test_blackbox_sync_wait_require_rules_fails_closed_when_busy(monkeypatch, capsys):
     class BusyLock:
         def __enter__(self):

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -270,6 +270,105 @@ def test_blackbox_sync_public_graph_subscribes_without_join(monkeypatch):
     assert join_calls == []
 
 
+def test_blackbox_sync_waits_for_custom_public_graph_catchup(monkeypatch):
+    events = []
+    statuses = iter([
+        {"jobId": "old", "status": "done"},
+        {"jobId": "old", "status": "done"},
+        {"jobId": "fresh", "status": "running"},
+        {"jobId": "fresh", "status": "done"},
+    ])
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, cg_id):
+            events.append(("subscribe", cg_id))
+            return {"catchup": {"jobId": "fresh", "status": "running"}}
+
+        def catchup_status(self, cg_id):
+            events.append(("status", cg_id))
+            return next(statuses)
+
+    class FakeRuleset:
+        def __init__(self, public):
+            self.public = public
+
+        def counts(self):
+            return {
+                "injection": self.public,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return self.public if source == "public" else 0
+
+    refreshes = []
+    peeks = []
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(
+            context_graph_id="0xabc/custom-public-graph",
+            dkg_url=constants.DEFAULT_DKG_URL,
+        ),
+    )
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda _cfg, _client: refreshes.append(True) or FakeRuleset(2),
+    )
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "peek",
+        lambda _cfg: peeks.append(True) or FakeRuleset(1),
+    )
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync_impl(args) == 0
+    assert events == [
+        ("status", "0xabc/custom-public-graph"),
+        ("subscribe", "0xabc/custom-public-graph"),
+        ("status", "0xabc/custom-public-graph"),
+        ("status", "0xabc/custom-public-graph"),
+        ("status", "0xabc/custom-public-graph"),
+    ]
+    assert len(peeks) == 2
+    assert len(refreshes) == 1
+
+
+def test_blackbox_sync_wait_does_not_start_a_second_process(monkeypatch, capsys):
+    class BusyLock:
+        def __enter__(self):
+            return False
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(context_graph_id="0xabc/custom-public-graph"),
+    )
+    monkeypatch.setattr(cli_mod, "_uses_managed_dkg", lambda _cfg, _args: False)
+    monkeypatch.setattr(cli_mod, "_managed_sync_lock", BusyLock)
+    monkeypatch.setattr(
+        cli_mod,
+        "_cmd_sync_impl",
+        lambda _args: (_ for _ in ()).throw(AssertionError("second sync must not start")),
+    )
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync(args) == 0
+    assert "already running" in capsys.readouterr().out
+
+
 def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypatch, capsys):
     refreshes = []
     events = []

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -116,6 +116,7 @@ def test_managed_sync_migrates_to_native_reconciliation_without_final_restart(
     states = []
     current = {
         "status": "done",
+        "context_graph_id": cfg.context_graph_id,
         "public_entries": 17_000,
         "community_entries": 0,
     }
@@ -343,7 +344,7 @@ def test_blackbox_sync_waits_for_custom_public_graph_catchup(monkeypatch):
     assert len(refreshes) == 1
 
 
-def test_blackbox_sync_wait_does_not_start_a_second_process(monkeypatch, capsys):
+def test_blackbox_sync_wait_require_rules_fails_closed_when_busy(monkeypatch, capsys):
     class BusyLock:
         def __enter__(self):
             return False
@@ -365,8 +366,128 @@ def test_blackbox_sync_wait_does_not_start_a_second_process(monkeypatch, capsys)
     )
 
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
-    assert cli_mod._cmd_sync(args) == 0
+    assert cli_mod._cmd_sync(args) == 2
     assert "already running" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("retryable_state", ["deferred", "unreachable"])
+def test_custom_public_sync_retries_terminal_job_and_adopts_replacement(
+    monkeypatch,
+    capsys,
+    retryable_state,
+):
+    subscriptions = []
+    status_jobs = []
+    clock = {"value": 0.0}
+
+    def monotonic():
+        clock["value"] += 0.5
+        return clock["value"]
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, cg_id):
+            job_id = "fresh-1" if not subscriptions else "fresh-2"
+            subscriptions.append((cg_id, job_id))
+            return {"catchup": {"jobId": job_id, "status": "queued"}}
+
+        def catchup_status(self, cg_id, *, job_id=None):
+            status_jobs.append((cg_id, job_id))
+            if job_id == "fresh-1":
+                return {"jobId": job_id, "status": retryable_state}
+            if job_id == "fresh-2" and len(status_jobs) == 3:
+                return {"jobId": job_id, "status": "running"}
+            if job_id == "fresh-2":
+                return {"jobId": job_id, "status": "done"}
+            return {"jobId": "old", "status": "done"}
+
+    class FakeRuleset:
+        def __init__(self, public):
+            self.public = public
+
+        def counts(self):
+            return {
+                "injection": self.public,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return self.public if source == "public" else 0
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
+    )
+    monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: FakeRuleset(1))
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: FakeRuleset(2))
+    monkeypatch.setattr(cli_mod.time, "monotonic", monotonic)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync(args) == 0
+    assert [job_id for _cg_id, job_id in subscriptions] == ["fresh-1", "fresh-2"]
+    assert [job_id for _cg_id, job_id in status_jobs] == [
+        None,
+        "fresh-1",
+        "fresh-2",
+        "fresh-2",
+    ]
+    assert cli_mod.sync_state.read_for_graph("owner/custom")["status"] == "done"
+    assert (
+        f"Retrying DKG catch-up after {retryable_state} state"
+        in capsys.readouterr().out
+    )
+
+
+def test_custom_public_sync_polls_original_job_when_latest_changes(monkeypatch):
+    status_jobs = []
+
+    class FakeClient:
+        def __init__(self, url, **_kwargs):
+            self.url = url
+
+        def subscribe_context_graph(self, _cg_id):
+            return {"catchup": {"jobId": "fresh", "status": "queued"}}
+
+        def catchup_status(self, _cg_id, *, job_id=None):
+            status_jobs.append(job_id)
+            if job_id == "fresh":
+                return {"jobId": "fresh", "status": "done"}
+            if len(status_jobs) == 1:
+                return {"jobId": "old", "status": "done"}
+            return {"jobId": "newer-unrelated", "status": "running"}
+
+    class FakeRuleset:
+        def counts(self):
+            return {
+                "injection": 1,
+                "escalation": 0,
+                "dependency": 0,
+                "fileaccess": 0,
+                "skill": 0,
+            }
+
+        def graph_count(self, source):
+            return 1 if source == "public" else 0
+
+    monkeypatch.setattr(cli_mod, "DkgClient", FakeClient)
+    monkeypatch.setattr(
+        cli_mod,
+        "load_blackbox_config",
+        lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
+    )
+    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: FakeRuleset())
+
+    args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
+    assert cli_mod._cmd_sync(args) == 0
+    assert status_jobs == [None, "fresh"]
 
 
 def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypatch, capsys):

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -230,7 +230,11 @@ def test_blackbox_sync_require_rules_fails_empty_ruleset(monkeypatch, capsys):
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(context_graph_id="cg", dkg_url=constants.DEFAULT_DKG_URL),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda cfg, client: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda cfg, client, **_kwargs: FakeRuleset(),
+    )
 
     args = argparse.Namespace(wait=False, timeout=180, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
@@ -264,7 +268,11 @@ def test_blackbox_sync_public_graph_subscribes_without_join(monkeypatch):
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(context_graph_id="cg", dkg_url=constants.DEFAULT_DKG_URL),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda cfg, client: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda cfg, client, **_kwargs: FakeRuleset(),
+    )
 
     args = argparse.Namespace(wait=False, timeout=180, require_rules=True)
     assert cli_mod._cmd_sync(args) == 0
@@ -322,7 +330,7 @@ def test_blackbox_sync_waits_for_custom_public_graph_catchup(monkeypatch):
     monkeypatch.setattr(
         cli_mod.ruleset,
         "refresh",
-        lambda _cfg, _client: refreshes.append(True) or FakeRuleset(2),
+        lambda _cfg, _client, **kwargs: refreshes.append(kwargs) or FakeRuleset(2),
     )
     monkeypatch.setattr(
         cli_mod.ruleset,
@@ -341,7 +349,7 @@ def test_blackbox_sync_waits_for_custom_public_graph_catchup(monkeypatch):
         ("status", "0xabc/custom-public-graph"),
     ]
     assert len(peeks) == 2
-    assert len(refreshes) == 1
+    assert refreshes == [{"force_query": True}]
 
 
 def test_blackbox_sync_wait_require_rules_fails_closed_when_busy(monkeypatch, capsys):
@@ -426,7 +434,11 @@ def test_custom_public_sync_retries_terminal_job_and_adopts_replacement(
         lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
     )
     monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: FakeRuleset(1))
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: FakeRuleset(2))
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda *_args, **_kwargs: FakeRuleset(2),
+    )
     monkeypatch.setattr(cli_mod.time, "monotonic", monotonic)
     monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
 
@@ -483,7 +495,11 @@ def test_custom_public_sync_polls_original_job_when_latest_changes(monkeypatch):
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda *_args, **_kwargs: FakeRuleset(),
+    )
 
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
     assert cli_mod._cmd_sync(args) == 0
@@ -539,7 +555,11 @@ def test_custom_public_sync_retries_exact_job_after_transient_status_error(
         "load_blackbox_config",
         lambda: config_mod.BlackboxConfig(context_graph_id="owner/custom"),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda *_args, **_kwargs: FakeRuleset(),
+    )
     monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
 
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
@@ -610,7 +630,7 @@ def test_blackbox_sync_waits_for_public_vm_when_community_arrives_first(monkeypa
         def graph_count(self, source):
             return self.public if source == "public" else 5
 
-    def fake_refresh(cfg, client):
+    def fake_refresh(cfg, client, **_kwargs):
         refreshes.append((cfg, client))
         return FakeRuleset(public=2 if len(refreshes) > 1 else 0)
 
@@ -724,7 +744,7 @@ def test_blackbox_sync_recovers_curator_snapshot_then_waits_for_vm(
     )
     last_public = {"value": 6_875}
 
-    def refresh(_cfg, _client):
+    def refresh(_cfg, _client, **_kwargs):
         events.append(("refresh",))
         try:
             last_public["value"] = next(public_counts)
@@ -824,8 +844,8 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
         ),
     )
 
-    def refresh(_cfg, _client):
-        refresh_calls.append(True)
+    def refresh(_cfg, _client, **kwargs):
+        refresh_calls.append(kwargs)
         return FakeRuleset(25_000)
 
     monkeypatch.setattr(cli_mod.ruleset, "refresh", refresh)
@@ -837,6 +857,7 @@ def test_blackbox_sync_uses_authoritative_publisher_for_empty_local_store(
     assert ("subscribe", constants.DEFAULT_CONTEXT_GRAPH_ID) in events
     assert curator_events[0][1] == constants.DEFAULT_CONTEXT_GRAPH_ID
     assert len(refresh_calls) == 2
+    assert {"force_query": True} in refresh_calls
     assert "25,000 public VM" in capsys.readouterr().out
 
 
@@ -907,7 +928,11 @@ def test_required_release_sync_fails_when_subscription_cannot_be_persisted(
             graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
         ),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda *_args: PublicRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda *_args, **_kwargs: PublicRuleset(),
+    )
     monkeypatch.setattr(cli_mod.ruleset, "peek", lambda *_args: PublicRuleset())
     monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(state))
     monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
@@ -981,7 +1006,11 @@ def test_blackbox_sync_fails_instead_of_waiting_on_empty_zero_insert_snapshot(
         ),
     )
     monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: EmptyRuleset())
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda _cfg, _client: EmptyRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda _cfg, _client, **_kwargs: EmptyRuleset(),
+    )
     monkeypatch.setattr(
         cli_mod.sync_state,
         "write",
@@ -1059,7 +1088,9 @@ def test_required_release_sync_persists_subscription_after_direct_connect_failur
     )
     monkeypatch.setattr(cli_mod.ruleset, "peek", lambda _cfg: EmptyRuleset())
     monkeypatch.setattr(
-        cli_mod.ruleset, "refresh", lambda _cfg, _client: EmptyRuleset()
+        cli_mod.ruleset,
+        "refresh",
+        lambda _cfg, _client, **_kwargs: EmptyRuleset(),
     )
 
     args = argparse.Namespace(wait=True, timeout=3_600, require_rules=True)
@@ -1112,7 +1143,16 @@ def test_authoritative_recovery_retries_fresh_node_peer_discovery(
         FakeClient(), "owner/public", "publisher", cli_mod.time.monotonic() + 30
     )
     assert connects == ["publisher", "publisher"]
-    assert any(details.get("phase") == "discovering-verifiable-source" for _, details in states)
+    discovery_states = [
+        details
+        for _, details in states
+        if details.get("phase") == "discovering-verifiable-source"
+    ]
+    assert discovery_states
+    assert all(
+        details.get("context_graph_id") == "owner/public"
+        for details in discovery_states
+    )
     assert "fresh-node warm-up" in capsys.readouterr().out
 
 
@@ -1141,7 +1181,10 @@ def test_fresh_node_discovery_uses_configured_relay_circuit_fallback(tmp_path):
             return {"connected": True}
 
     cli_mod._connect_verifiable_source(
-        FakeClient(), "publisher", cli_mod.time.monotonic() + 30
+        FakeClient(),
+        "owner/public",
+        "publisher",
+        cli_mod.time.monotonic() + 30,
     )
 
     assert attempted == [
@@ -1219,7 +1262,11 @@ def test_blackbox_sync_does_not_accept_deferred_catchup_as_complete(
             graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
         ),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda _cfg, _client: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda _cfg, _client, **_kwargs: FakeRuleset(),
+    )
     monkeypatch.setattr(
         cli_mod.sync_state,
         "write",
@@ -1276,7 +1323,7 @@ def test_blackbox_sync_does_not_fall_back_to_generic_running_catchup(monkeypatch
     monkeypatch.setattr(
         cli_mod.ruleset,
         "refresh",
-        lambda *_args: (_ for _ in ()).throw(
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("VM must not be queried during durable catch-up")
         ),
     )
@@ -1941,7 +1988,9 @@ def test_blackbox_sync_ctrl_c_records_cancellation_and_returns_130(monkeypatch, 
     monkeypatch.setattr(
         cli_mod.ruleset,
         "refresh",
-        lambda _cfg, _client: (_ for _ in ()).throw(KeyboardInterrupt()),
+        lambda _cfg, _client, **_kwargs: (_ for _ in ()).throw(
+            KeyboardInterrupt()
+        ),
     )
     monkeypatch.setattr(cli_mod.sync_state, "write", write_state)
     monkeypatch.setattr(cli_mod.sync_state, "read", lambda: dict(state))
@@ -2047,7 +2096,11 @@ def test_blackbox_sync_does_not_accept_stale_public_rows_after_fresh_catchup_fai
             graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
         ),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda cfg, client: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda cfg, client, **_kwargs: FakeRuleset(),
+    )
 
     args = argparse.Namespace(wait=True, timeout=30, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
@@ -2118,7 +2171,7 @@ def test_blackbox_sync_uses_curator_when_generic_catchup_peer_fails(monkeypatch,
     )
     last_public = {"value": 2}
 
-    def refresh(_cfg, _client):
+    def refresh(_cfg, _client, **_kwargs):
         try:
             last_public["value"] = next(public_counts)
         except StopIteration:
@@ -2187,7 +2240,7 @@ def test_blackbox_sync_private_waits_for_approval_then_subscribes(monkeypatch):
         join_calls.append((args, kwargs))
         return ("join delivered; approval pending", len(join_calls) >= 2)
 
-    def fake_refresh(cfg, client):
+    def fake_refresh(cfg, client, **_kwargs):
         refresh_calls.append((cfg, client))
         rs = FakeRuleset()
         if len(refresh_calls) >= 4:
@@ -2267,7 +2320,11 @@ def test_blackbox_sync_restarts_stale_empty_catchup_after_approval(monkeypatch, 
             graph_peer_id=constants.DEFAULT_GRAPH_PEER_ID,
         ),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda cfg, client: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda cfg, client, **_kwargs: FakeRuleset(),
+    )
 
     args = argparse.Namespace(wait=False, timeout=180, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2
@@ -2322,7 +2379,7 @@ def test_blackbox_sync_waits_for_fresh_dkg_catchup_without_restarting(monkeypatc
         def graph_count(self, source):
             return self.public if source == "public" else 0
 
-    def fake_refresh(cfg, client):
+    def fake_refresh(cfg, client, **_kwargs):
         refreshes.append((cfg, client))
         return FakeRuleset(public=2 if len(refreshes) > 1 else 0)
 
@@ -2389,7 +2446,11 @@ def test_blackbox_sync_reports_pending_approval_when_catchup_is_denied(monkeypat
         "_request_join",
         lambda *args, **kwargs: ("Join request sent; approval is pending.", False),
     )
-    monkeypatch.setattr(cli_mod.ruleset, "refresh", lambda cfg, client: FakeRuleset())
+    monkeypatch.setattr(
+        cli_mod.ruleset,
+        "refresh",
+        lambda cfg, client, **_kwargs: FakeRuleset(),
+    )
 
     args = argparse.Namespace(wait=False, timeout=180, require_rules=True)
     assert cli_mod._cmd_sync(args) == 2

--- a/tests/plugins/test_blackbox_vm_only.py
+++ b/tests/plugins/test_blackbox_vm_only.py
@@ -226,7 +226,11 @@ def test_dashboard_keeps_old_rules_and_advances_verified_count_during_sync(monke
     monkeypatch.setattr(
         server.sync_state,
         "read",
-        lambda: {"status": "running", "public_entries": 10},
+        lambda: {
+            "status": "running",
+            "context_graph_id": Cfg.context_graph_id,
+            "public_entries": 10,
+        },
     )
 
     assert server._sync_ruleset_once(lambda: Cfg(), Client, Rules) == {

--- a/tests/test_blackbox_dashboard_chat.py
+++ b/tests/test_blackbox_dashboard_chat.py
@@ -118,6 +118,7 @@ def test_dashboard_keeps_partial_vm_count_loading_during_curator_transfer(monkey
         "passes": 2,
         "inserted_triples": 160_000,
         "public_entries": 460,
+        "context_graph_id": cfg.context_graph_id,
     }
     monkeypatch.setattr(config, "load_blackbox_config", lambda: cfg)
     monkeypatch.setattr(ruleset, "peek", lambda _cfg=None: PartialRuleset())


### PR DESCRIPTION
## Summary

- Make `blackbox sync --wait` track the exact catch-up job created for the configured public graph, including custom graphs, and retry bounded `deferred` or `unreachable` jobs without adopting unrelated status.
- Serialize blocking syncs and ruleset rebuilds across processes. Ordinary concurrent refreshes reuse one completed generation, while post-catch-up barriers always execute a new VM query after acquiring the lock.
- Keep serving last-good rules while catch-up is active or a barrier refresh is unavailable, but fail closed for `--require-rules`: lock contention, query failure, and empty post-barrier snapshots cannot mark sync complete.
- Scope cache generations and transfer state to the configured Context Graph, including publisher-discovery heartbeats, so graph switches cannot reuse stale rules or status.
- Live diagnosis found verified VM rows advancing while `ruleset.json` and the dashboard remained stale under concurrent refreshes. Missing DKG KAs are a separate synchronization issue and are intentionally not repaired here.

## Related

- Follow-up to #8
- Related to the broader coordinator proposal in #3
- DKG publisher/receiver convergence for missing KAs remains separate from this Blackbox cache lifecycle fix

## Files changed

| File | What |
|------|------|
| `plugins/blackbox/cli.py` | Serialize blocking syncs, pin exact catch-up jobs, retry recoverable states, and require a complete post-barrier cache refresh |
| `plugins/blackbox/ruleset.py` | Add graph-scoped generations, cross-process locking, waited-generation reuse, and fail-closed barrier refresh outcomes |
| `plugins/blackbox/dkg_client.py` | Preserve HTTP status codes and support exact catch-up job queries |
| `plugins/blackbox/sync_state.py` | Scope persisted transfer state to one Context Graph |
| `plugins/blackbox/dashboard/server.py` | Ignore transfer state from other graphs and serve last-good cache during sync |
| `tests/plugins/test_blackbox_*.py`, `tests/test_blackbox_dashboard_chat.py` | Cover job races, graph switches, process/Windows locks, discovery scope, and barrier failures |

## Test plan

- [x] Focused barrier, custom-graph, and discovery regressions: 12 passed
- [x] Affected Blackbox suite: 20 files, 442 passed, 0 failed, with five canonical durable-sync failures excluded
- [x] Ruff on changed Python files
- [x] Windows-footgun scanner
- [x] `git diff --check`
- [ ] GitHub Actions slice 7 and aggregate gate: expected to remain red from six failures reproduced identically on canonical `umanitek/main` at `f742690596a9fa32165c3a4e3713114f5ee7ef9a`

The six base failures are the five durable-sync tests excluded above plus `tests/tools/test_windows_native_support.py::TestReadmeNoLongerSaysWindowsUnsupported::test_readme_mentions_powershell_installer`. The PR does not change `README.md`, and an identical six-selector command fails on both the base commit and this branch.
