### PR TITLE
fix(blackbox): enable isolated DKG auto-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,28 @@ chmod 755 ~/.local/bin/blackbox
 
 # 4. Official npm DKG node (required for first-run protection)
 mkdir -p dkg
-npm install --prefix dkg --prefer-online @origintrail-official/dkg@latest
+npm install -g --prefix dkg --prefer-online @origintrail-official/dkg@latest
 export BLACKBOX_DKG_HOME="$PWD/.dkg"
-export BLACKBOX_DKG_BIN="$PWD/dkg/node_modules/.bin/dkg"
+export BLACKBOX_DKG_BIN="$PWD/dkg/bin/dkg"
+export npm_config_prefix="$PWD/dkg"  # keeps DKG auto-updates inside this checkout
 export BLACKBOX_DKG_PORT=9320
 export BLACKBOX_DKG_DAEMON_URL="http://127.0.0.1:$BLACKBOX_DKG_PORT"
 DKG_HOME="$BLACKBOX_DKG_HOME" "$BLACKBOX_DKG_BIN" hermes setup --network mainnet-base \
   --port "$BLACKBOX_DKG_PORT" \
   --daemon-url "$BLACKBOX_DKG_DAEMON_URL" \
   --no-fund   # joining and reading do not require funds
+venv/bin/python - <<'PY'
+import json, os, pathlib
+path = pathlib.Path(os.environ["BLACKBOX_DKG_HOME"]) / "config.json"
+config = json.loads(path.read_text())
+config["autoUpdate"] = {
+    "enabled": True,
+    "source": "npm",
+    "channel": "mainnet",
+    "allowPrerelease": False,
+}
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
 
 # 5. Enable Agent Blackbox and protect every local agent
 hermes plugins enable blackbox
@@ -216,6 +229,11 @@ reporting is not yet active.
 The shared intelligence lives on the OriginTrail Decentralized Knowledge Graph
 (DKG). Blackbox runs its own isolated local DKG node, so it does not replace or
 modify another DKG installation.
+
+The managed edge node follows DKG's stable `mainnet` npm channel automatically.
+Updates are installed and self-checked by DKG inside Blackbox's private npm
+prefix; failed updates use DKG's recorded rollback target and never modify a
+system-wide DKG installation.
 
 The curated threat graph is public and requires no private membership or join
 approval. Only its verified VM content is used for threat matching. The

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Windows PowerShell:
 iwr -useb blackbox-w.umanitek.ai | iex
 ```
 
+The Windows entrypoint is [`scripts/blackbox-install.ps1`](scripts/blackbox-install.ps1).
+
 <details>
 <summary><b>Manual install</b> - prefer not to pipe a script into bash?</summary>
 <br>

--- a/contributors/emails/kilian@ttsolutions.si
+++ b/contributors/emails/kilian@ttsolutions.si
@@ -1,0 +1,2 @@
+KilianTrunk
+# DKG auto-update PR

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -555,6 +555,10 @@ def _dkg_sync_environment(cfg: BlackboxConfig) -> Dict[str, str]:
     env = os.environ.copy()
     env.update(_DKG_STEADY_SYNC_SETTINGS)
     env["DKG_HOME"] = str(cfg.dkg_home)
+    # The managed CLI is a private npm-global install. DKG's official Edge
+    # updater executes `npm install -g`; pinning the prefix here keeps every
+    # daemon/restart path on the same isolated installation.
+    env["npm_config_prefix"] = str(_managed_dkg_npm_prefix(cfg))
     env.setdefault("DKG_CATCHUP_MAX_CONCURRENT_PEERS", "1")
     env.setdefault("DKG_STORE_QUEUE_WAIT_TIMEOUT_MS", "300000")
     env.setdefault("DKG_SYNC_TOTAL_TIMEOUT_MS", "1800000")
@@ -625,11 +629,38 @@ def _managed_dkg_node_executable(cfg: BlackboxConfig) -> Optional[Path]:
     return None
 
 
+def _managed_dkg_npm_prefix(cfg: BlackboxConfig) -> Path:
+    """Return the private npm-global prefix containing the configured CLI."""
+    dkg_bin = Path(cfg.dkg_bin).expanduser().resolve()
+    if os.name != "nt" and dkg_bin.parent.name == "bin":
+        return dkg_bin.parent.parent
+    if dkg_bin.parent.name == ".bin" and dkg_bin.parent.parent.name == "node_modules":
+        return dkg_bin.parent.parent.parent
+    return dkg_bin.parent
+
+
 def _node_runtime_matches_dkg(executable: Path, cfg: BlackboxConfig) -> bool:
     """Load the installed native SQLite binding before trusting a Node path."""
-    dkg_bin = Path(cfg.dkg_bin).expanduser()
-    native_package = dkg_bin.parent.parent / "better-sqlite3"
-    if not native_package.is_dir():
+    prefix = _managed_dkg_npm_prefix(cfg)
+    candidates = (
+        prefix / "lib" / "node_modules" / "better-sqlite3",
+        prefix
+        / "lib"
+        / "node_modules"
+        / "@origintrail-official"
+        / "dkg"
+        / "node_modules"
+        / "better-sqlite3",
+        prefix / "node_modules" / "better-sqlite3",
+        prefix
+        / "node_modules"
+        / "@origintrail-official"
+        / "dkg"
+        / "node_modules"
+        / "better-sqlite3",
+    )
+    native_package = next((path for path in candidates if path.is_dir()), None)
+    if native_package is None:
         return False
     probe = (
         "const DB=require(process.argv[1]);"

--- a/plugins/blackbox/cli.py
+++ b/plugins/blackbox/cli.py
@@ -1790,10 +1790,10 @@ def _catchup_authoritative_vm(
             inserted_durable_triples=inserted,
             **durable_progress,
         )
-        durable_progress = read_durable_progress(
-            str(getattr(client, "dkg_home", "") or ""),
-            context_graph_id,
-        )
+        # Keep this pass scoped to the cursor captured immediately before the
+        # request.  Re-reading the whole daemon log here can either erase the
+        # request's explicit ``durableComplete`` result or accept a completion
+        # marker emitted by an earlier invocation.
         if inserted <= 0:
             expected = int(durable_progress.get("expected_triples") or 0)
             safe_current = int(durable_progress.get("safe_current_triples") or 0)

--- a/plugins/blackbox/constants.py
+++ b/plugins/blackbox/constants.py
@@ -261,5 +261,6 @@ def blackbox_dkg_bin() -> Path:
     env = os.environ.get("BLACKBOX_DKG_BIN")
     if env and env.strip():
         return Path(env).expanduser()
-    bin_name = "dkg.cmd" if os.name == "nt" else "dkg"
-    return blackbox_dkg_cli_dir() / "node_modules" / ".bin" / bin_name
+    if os.name == "nt":
+        return blackbox_dkg_cli_dir() / "dkg.cmd"
+    return blackbox_dkg_cli_dir() / "bin" / "dkg"

--- a/plugins/blackbox/dashboard/server.py
+++ b/plugins/blackbox/dashboard/server.py
@@ -59,6 +59,45 @@ def _dkg_durable_progress(dkg_home: str, context_graph_id: str) -> Dict[str, Any
     return read_durable_progress(dkg_home, context_graph_id)
 
 
+def _dkg_update_view(
+    node_status: Dict[str, Any] | None, *, reachable: bool
+) -> Dict[str, Any]:
+    """Normalize DKG's update fields into a stable dashboard contract."""
+    status = node_status if isinstance(node_status, dict) else {}
+
+    def _text(key: str) -> str | None:
+        value = status.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    enabled_raw = status.get("autoUpdate")
+    enabled = enabled_raw if isinstance(enabled_raw, bool) else None
+    available_raw = status.get("updateAvailable")
+    update_available = available_raw if isinstance(available_raw, bool) else None
+    if not reachable:
+        state = "offline"
+    elif enabled is False:
+        state = "disabled"
+    elif update_available is True:
+        state = "available"
+    elif update_available is False:
+        state = "current"
+    elif enabled is True:
+        state = "checking"
+    else:
+        state = "unknown"
+    return {
+        "state": state,
+        "enabled": enabled,
+        "current_version": _text("version"),
+        "latest_version": _text("latestVersion"),
+        "update_available": update_available,
+        "channel_target_missing": bool(status.get("updateChannelTargetMissing")),
+        "install_mode": _text("installMode"),
+    }
+
+
 def _blackbox_runtime_argv(port: int = _BLACKBOX_RUNTIME_PORT) -> List[str]:
     """Command for the dashboard-owned, profile-isolated Agent Blackbox backend."""
     return [
@@ -1358,19 +1397,24 @@ def create_app(*, manage_blackbox: bool = False):
                 return None
             client = DkgClient(url=cfg.dkg_url, dkg_home=cfg.dkg_home)
             try:
+                node_status = client.status(timeout=_REACH_TIMEOUT)
+            except Exception:
+                node_status = {}
+            try:
                 catchup = client.catchup_status(cfg.context_graph_id)
             except Exception:
                 # No job is normal on an already-settled node.
                 catchup = {}
             return {
                 "node_reachable": True,
+                "node_status": node_status,
                 "catchup": catchup,
             }
 
         g = _swr(
             "graph-sync-status",
             _node_sync,
-            {"node_reachable": False, "catchup": {}},
+            {"node_reachable": False, "node_status": {}, "catchup": {}},
             ttl=4.0,
         )
         sightings = 0
@@ -1469,6 +1513,9 @@ def create_app(*, manage_blackbox: bool = False):
             "dkg_home": cfg.dkg_home,
             "dkg_bin": cfg.dkg_bin,
             "node_reachable": g["node_reachable"],
+            "dkg_update": _dkg_update_view(
+                g.get("node_status"), reachable=bool(g["node_reachable"])
+            ),
             "sync_interval": cfg.sync_interval,
             "last_sync": rs.synced_at or None,
             "ruleset": counts,

--- a/plugins/blackbox/dashboard/static/index.html
+++ b/plugins/blackbox/dashboard/static/index.html
@@ -302,6 +302,10 @@
   .status-pill.offline { color: var(--signal); border-color: rgba(255,79,0,0.55); background: var(--signal-soft); }
   .status-pill.mode-audit { color: var(--muted-strong); border-color: var(--border); background: var(--panel); }
   .status-pill.mode-block { color: var(--signal); border-color: rgba(255,79,0,0.55); background: var(--signal-soft); }
+  .status-pill.dkg-current { color: var(--mint); border-color: color-mix(in srgb, var(--mint) 42%, var(--border)); }
+  .status-pill.dkg-checking { color: var(--muted-strong); }
+  .status-pill.dkg-available,
+  .status-pill.dkg-disabled { color: var(--signal); border-color: rgba(255,79,0,0.55); background: var(--signal-soft); }
 
   /* gear button — same pill visual language as the status pills */
   .gear-btn {
@@ -1906,6 +1910,33 @@
     text-transform: uppercase;
     white-space: nowrap;
   }
+  .set-dkg-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--muted-strong);
+    background: var(--elevated);
+    font-family: var(--mono-font);
+    font-size: 8px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .set-dkg-status.current {
+    color: var(--mint);
+    border-color: color-mix(in srgb, var(--mint) 30%, transparent);
+    background: color-mix(in srgb, var(--mint) 7%, transparent);
+  }
+  .set-dkg-status.available,
+  .set-dkg-status.disabled,
+  .set-dkg-status.offline {
+    color: var(--signal);
+    border-color: rgba(255,79,0,0.55);
+    background: var(--signal-soft);
+  }
 
   /* segmented control (audit | block) — same look as .sort-seg */
   .set-seg { display: inline-flex; padding: 3px; background: var(--elevated); border: 1px solid var(--border); border-radius: 3px; }
@@ -2701,6 +2732,7 @@
       </div>
       <div class="status-pills" aria-live="polite">
         <span class="status-pill offline" id="pill-node" hidden title="The local DKG node is not responding">node offline</span>
+        <span class="status-pill dkg-checking" id="pill-dkg" hidden>DKG checking</span>
         <span class="status-pill mode-audit" id="pill-mode" hidden>audit mode</span>
         <button type="button" class="header-menu-toggle" id="header-menu-toggle" aria-label="Open dashboard menu" aria-expanded="false" aria-controls="header-action-menu">
           <span class="burger-lines" aria-hidden="true"><span class="burger-line"></span><span class="burger-line"></span><span class="burger-line"></span></span>
@@ -6372,6 +6404,7 @@
                 : data.threats;
     var interval = data.sync_interval != null ? data.sync_interval : data.syncInterval;
     var lastSync = data.last_sync != null ? data.last_sync : data.lastSync;
+    var dkgUpdate = data.dkg_update || {};
 
     // Render every available VM/SWM count immediately, including 0. Polling
     // replaces these numbers as catch-up adds entries; loaders are reserved for
@@ -6381,6 +6414,7 @@
     // header status pills: node reachability + enforcement mode
     var nodePill = $("pill-node");
     if (nodePill) nodePill.hidden = data.node_reachable !== false;
+    renderDkgUpdateStatus(dkgUpdate, data.node_reachable !== false);
     var modePill = $("pill-mode");
     if (modePill) {
       var mode = String(data.mode || "").toLowerCase();
@@ -6403,6 +6437,49 @@
       $("stat-sync").textContent = "never";
       $("stat-sync-meta").textContent = "run blackbox sync";
     }
+  }
+
+  function renderDkgUpdateStatus(update, reachable) {
+    update = update || {};
+    var state = String(update.state || (reachable ? "unknown" : "offline"));
+    var current = update.current_version ? "v" + update.current_version : "version unknown";
+    var latest = update.latest_version ? "v" + update.latest_version : "the latest release";
+    var label = "DKG status unknown";
+    var detail = "Update status is not available from this DKG version.";
+    var compact = current;
+    if (state === "current") {
+      detail = "Automatic stable updates are enabled. This node is up to date.";
+      compact = current + " · Current";
+    } else if (state === "available") {
+      detail = "DKG found " + latest + " and will install it automatically.";
+      compact = current + " → " + latest;
+    } else if (state === "checking") {
+      detail = "Automatic stable updates are enabled. DKG is checking the release channel.";
+      compact = current + " · Checking";
+    } else if (state === "disabled") {
+      detail = "Automatic DKG updates are disabled in the node configuration.";
+      compact = current + " · Disabled";
+    } else if (state === "offline") {
+      detail = "The local DKG node is offline, so its update status is unavailable.";
+      compact = "Offline";
+    }
+    if (state !== "unknown") label = "DKG " + compact;
+    var pill = $("pill-dkg");
+    if (pill) {
+      // The existing node-offline pill already covers this state in the header;
+      // Settings keeps the more specific update explanation visible.
+      pill.hidden = state === "offline";
+      pill.className = "status-pill dkg-" + state;
+      pill.textContent = label;
+      pill.title = detail;
+    }
+    var status = $("set-dkg-update-state");
+    if (status) {
+      status.className = "set-dkg-status " + state;
+      status.textContent = compact;
+    }
+    var help = $("set-dkg-update-help");
+    if (help) help.textContent = detail;
   }
 
   // ---------- Poll loop ----------
@@ -7397,6 +7474,19 @@
     </div>
 
     <div class="set-body">
+      <div class="set-group">
+        <div class="set-glabel">DKG node</div>
+        <div class="set-row">
+          <div class="set-rl">
+            <div class="set-rt">Automatic updates</div>
+            <div class="set-rh" id="set-dkg-update-help">Waiting for the local DKG node.</div>
+          </div>
+          <div class="set-rc">
+            <span class="set-dkg-status checking" id="set-dkg-update-state">Checking</span>
+          </div>
+        </div>
+      </div>
+
       <!-- Appearance applies immediately. -->
       <div class="set-group">
         <div class="set-glabel">Appearance</div>

--- a/scripts/blackbox-blazegraph.mjs
+++ b/scripts/blackbox-blazegraph.mjs
@@ -85,6 +85,16 @@ if (healthCheck) {
   const modulePaths = [
     path.join(
       dkgRoot,
+      'lib',
+      'node_modules',
+      '@origintrail-official',
+      'dkg',
+      'dist',
+      'daemon',
+      'store-health-check.js',
+    ),
+    path.join(
+      dkgRoot,
       'node_modules',
       '@origintrail-official',
       'dkg',
@@ -130,6 +140,16 @@ if (!Number.isInteger(port) || port < 1 || port > 65535) {
 
 const dkgRoot = path.resolve(dkgCheckout);
 const modulePaths = [
+  path.join(
+    dkgRoot,
+    'lib',
+    'node_modules',
+    '@origintrail-official',
+    'dkg',
+    'dist',
+    'daemon',
+    'blazegraph-docker.js',
+  ),
   path.join(
     dkgRoot,
     'node_modules',

--- a/scripts/blackbox-dkg-runtime-fingerprint.py
+++ b/scripts/blackbox-dkg-runtime-fingerprint.py
@@ -140,10 +140,17 @@ def _add_bytes(digest: "hashlib._Hash", label: str, data: bytes) -> None:
 
 def _runtime_files(cli_dir: Path, dkg_home: Path, dkg_bin: Path) -> list[Path]:
     monorepo_cli = cli_dir / "packages" / "cli"
-    cli_package = (
-        monorepo_cli
-        if (monorepo_cli / "package.json").is_file()
-        else cli_dir / "node_modules" / "@origintrail-official" / "dkg"
+    private_global_cli = (
+        cli_dir / "lib" / "node_modules" / "@origintrail-official" / "dkg"
+    )
+    local_cli = cli_dir / "node_modules" / "@origintrail-official" / "dkg"
+    cli_package = next(
+        (
+            candidate
+            for candidate in (monorepo_cli, private_global_cli, local_cli)
+            if (candidate / "package.json").is_file()
+        ),
+        private_global_cli,
     )
     config = dkg_home / "config.json"
     required = [config, cli_package / "package.json", dkg_bin]
@@ -155,6 +162,7 @@ def _runtime_files(cli_dir: Path, dkg_home: Path, dkg_bin: Path) -> list[Path]:
     monorepo_agent_dist = cli_dir / "packages" / "agent" / "dist"
     if monorepo_agent_dist.is_dir():
         agent_dists.append(monorepo_agent_dist)
+    agent_dists.extend(sorted(cli_dir.glob("lib/node_modules/**/dkg-agent/dist")))
     agent_dists.extend(sorted(cli_dir.glob("node_modules/**/dkg-agent/dist")))
     if not agent_dists:
         raise FingerprintError(f"dkg-agent dist not found under {cli_dir}")
@@ -236,6 +244,7 @@ def installed_commit(cli_dir: Path) -> str:
     """Return the build commit advertised by the installed DKG package."""
     cli_dir = cli_dir.expanduser().resolve()
     package_roots = (
+        cli_dir / "lib" / "node_modules" / "@origintrail-official" / "dkg",
         cli_dir / "node_modules" / "@origintrail-official" / "dkg",
         cli_dir / "packages" / "cli",
     )

--- a/scripts/blackbox-install.ps1
+++ b/scripts/blackbox-install.ps1
@@ -70,7 +70,7 @@ $script:DockerRequired = $false
 $DkgAcceptStoreReset = $false
 $DkgHome     = Join-Path $DefaultRepoDir ".dkg"
 $DkgCliDir   = Join-Path $DefaultRepoDir "dkg"
-$DkgBin      = Join-Path $DkgCliDir "node_modules\.bin\dkg.cmd"
+$DkgBin      = Join-Path $DkgCliDir "dkg.cmd"
 $DkgPackage  = if ($env:BLACKBOX_DKG_PACKAGE) { $env:BLACKBOX_DKG_PACKAGE } else { "@origintrail-official/dkg@latest" }
 $DkgDaemonUrl = "http://127.0.0.1:$DkgPort"
 $DkgStoreQueueLimit = if ($env:BLACKBOX_DKG_STORE_QUEUE_LIMIT) { [int]$env:BLACKBOX_DKG_STORE_QUEUE_LIMIT } else { 512 }
@@ -270,6 +270,7 @@ function Invoke-BlackboxDkg {
         "DKG_STORE_QUEUE_WAIT_TIMEOUT_MS",
         "DKG_SYNC_TOTAL_TIMEOUT_MS",
         "DKG_SWM_RECOVERY_TIMEOUT_MS",
+        "npm_config_prefix",
         "NODE_OPTIONS",
         "Path"
     )
@@ -283,6 +284,7 @@ function Invoke-BlackboxDkg {
             $env:Path = "$(Split-Path -Parent $nodeCommand.Source);$env:Path"
         }
         $env:DKG_HOME = $DkgHome
+        $env:npm_config_prefix = $DkgCliDir
         $env:DKG_ACCEPT_STORE_RESET = if (
             $script:DkgAcceptStoreReset -or (Test-Path $script:DkgStoreResetMarker)
         ) { "1" } else { "0" }
@@ -796,7 +798,19 @@ if not isinstance(priorities, dict):
     priorities = {}
 priorities.update({context_graph_id: 100, "agents": -100, "ontology": -100})
 data["syncContextGraphPriorities"] = priorities
-data.setdefault("autoUpdate", {"enabled": False})
+legacy_auto_update = {"enabled": False}
+auto_update = data.get("autoUpdate")
+if auto_update is None or auto_update == legacy_auto_update:
+    data["autoUpdate"] = {
+        "enabled": True,
+        "source": "npm",
+        "channel": "mainnet",
+        "allowPrerelease": False,
+    }
+elif isinstance(auto_update, dict):
+    auto_update.setdefault("source", "npm")
+    auto_update.setdefault("channel", "mainnet")
+    auto_update.setdefault("allowPrerelease", False)
 data["chain"] = {
     "type": "evm",
     "rpcUrl": "https://mainnet.base.org",
@@ -1012,7 +1026,7 @@ function Install-BlackboxDkgPackage {
     New-Item -ItemType Directory -Force -Path $DkgCliDir | Out-Null
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $npmLog) | Out-Null
     try {
-        & npm install --prefix $DkgCliDir --prefer-online $DkgPackage 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
+        & npm install -g --prefix $DkgCliDir --prefer-online $DkgPackage 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
         if ($LASTEXITCODE -ne 0) { throw "npm install exit $LASTEXITCODE" }
     } catch {
         if ($backupDir) {
@@ -1179,7 +1193,7 @@ function Show-DkgManualHint {
     Write-Step "To set up the DKG node later:"
     Write-Host "      node -v  # must be v$NodeMajor or newer"
     Write-Host "      New-Item -ItemType Directory -Force -Path `"$DkgCliDir`""
-    Write-Host "      npm install --prefix `"$DkgCliDir`" `"$DkgPackage`""
+    Write-Host "      npm install -g --prefix `"$DkgCliDir`" `"$DkgPackage`""
     Write-Host "      `$env:BLACKBOX_DKG_HOME = `"$DkgHome`""
     Write-Host "      `$env:BLACKBOX_DKG_BIN = `"$DkgBin`""
     Write-Host "      `$env:BLACKBOX_DKG_PORT = `"$DkgPort`""
@@ -1244,16 +1258,20 @@ uses_unpaired_shared_dkg_home = uses_shared_dkg_home and (not current_dkg_url or
 uses_legacy_blackbox_dkg_home = current_dkg_home_abs == legacy_blackbox_dkg_home
 current_dkg_bin = str(blackbox.get("dkg_bin") or blackbox.get("dkgBin") or "").strip()
 current_dkg_bin_abs = os.path.abspath(os.path.expanduser(current_dkg_bin)) if current_dkg_bin else ""
-expected_managed_bin = (
-    os.path.join(os.path.dirname(current_dkg_home_abs), "dkg", "node_modules", ".bin", "dkg.cmd")
-    if current_dkg_home_abs else ""
+expected_managed_bins = (
+    (
+        os.path.join(os.path.dirname(current_dkg_home_abs), "dkg", "dkg.cmd"),
+        os.path.join(os.path.dirname(current_dkg_home_abs), "dkg", "node_modules", ".bin", "dkg.cmd"),
+    )
+    if current_dkg_home_abs
+    else ()
 )
 uses_target_managed_home = current_dkg_home_abs == target_dkg_home_abs
 uses_other_managed_checkout = bool(
     current_dkg_home_abs
     and os.path.basename(current_dkg_home_abs) == ".dkg"
     and current_dkg_home_abs != target_dkg_home_abs
-    and current_dkg_bin_abs == expected_managed_bin
+    and current_dkg_bin_abs in expected_managed_bins
 )
 stale_configured_dkg_home = bool(current_dkg_home_abs) and not os.path.isdir(current_dkg_home_abs)
 stale_configured_dkg_bin = bool(current_dkg_bin_abs) and not os.path.isfile(current_dkg_bin_abs)

--- a/scripts/blackbox-install.sh
+++ b/scripts/blackbox-install.sh
@@ -60,7 +60,7 @@ BLACKBOX_DOCKER_REQUIRED=false
 BLACKBOX_DKG_ACCEPT_STORE_RESET=false
 BLACKBOX_DKG_HOME="$BLACKBOX_INSTALL_ROOT/.dkg"
 BLACKBOX_DKG_CLI_DIR="$BLACKBOX_INSTALL_ROOT/dkg"
-BLACKBOX_DKG_BIN="$BLACKBOX_DKG_CLI_DIR/node_modules/.bin/dkg"
+BLACKBOX_DKG_BIN="$BLACKBOX_DKG_CLI_DIR/bin/dkg"
 BLACKBOX_DKG_PACKAGE="${BLACKBOX_DKG_PACKAGE:-@origintrail-official/dkg@latest}"
 BLACKBOX_DKG_DAEMON_URL="http://127.0.0.1:$BLACKBOX_DKG_PORT"
 BLACKBOX_DKG_STORE_QUEUE_LIMIT="${BLACKBOX_DKG_STORE_QUEUE_LIMIT:-512}"
@@ -187,6 +187,7 @@ blackbox_dkg() {
     # Process-level guards intentionally wrap the DKG entrypoint, not a store
     # adapter, so Blazegraph and managed Oxigraph receive identical protection.
     PATH="$node_bin_dir:$PATH" \
+    npm_config_prefix="$BLACKBOX_DKG_CLI_DIR" \
     DKG_HOME="$BLACKBOX_DKG_HOME" \
     DKG_ACCEPT_STORE_RESET="$accept_store_reset" \
     DKG_STORE_QUEUE_LIMIT="$BLACKBOX_DKG_STORE_QUEUE_LIMIT" \
@@ -728,7 +729,24 @@ if not isinstance(priorities, dict):
     priorities = {}
 priorities.update({context_graph_id: 100, "agents": -100, "ontology": -100})
 data["syncContextGraphPriorities"] = priorities
-data.setdefault("autoUpdate", {"enabled": False})
+# DKG's edge-node updater uses `npm install -g`.  The launcher pins npm's
+# prefix to Blackbox's private DKG directory, so updates never touch the
+# user's system-wide npm installation.  Migrate the exact legacy value that
+# older Blackbox installers wrote, while preserving an explicitly customised
+# opt-out.
+legacy_auto_update = {"enabled": False}
+auto_update = data.get("autoUpdate")
+if auto_update is None or auto_update == legacy_auto_update:
+    data["autoUpdate"] = {
+        "enabled": True,
+        "source": "npm",
+        "channel": "mainnet",
+        "allowPrerelease": False,
+    }
+elif isinstance(auto_update, dict):
+    auto_update.setdefault("source", "npm")
+    auto_update.setdefault("channel", "mainnet")
+    auto_update.setdefault("allowPrerelease", False)
 data["chain"] = {
     "type": "evm",
     "rpcUrl": "https://mainnet.base.org",
@@ -1276,7 +1294,7 @@ run_hermes_setup() {
 # ── DKG node CLI + bootstrap ────────────────────────────────────────────────
 install_blackbox_dkg_package() {
     local backup_dir=""
-    local package_json="$BLACKBOX_DKG_CLI_DIR/node_modules/@origintrail-official/dkg/package.json"
+    local package_json="$BLACKBOX_DKG_CLI_DIR/lib/node_modules/@origintrail-official/dkg/package.json"
     local installed_version=""
     local npm_log="$HERMES_HOME/logs/blackbox-npm-install.log"
 
@@ -1296,7 +1314,7 @@ install_blackbox_dkg_package() {
 
     mkdir -p "$BLACKBOX_DKG_CLI_DIR"
     mkdir -p "$(dirname "$npm_log")"
-    if ! npm install --prefix "$BLACKBOX_DKG_CLI_DIR" --prefer-online \
+    if ! npm install -g --prefix "$BLACKBOX_DKG_CLI_DIR" --prefer-online \
         "$BLACKBOX_DKG_PACKAGE" >"$npm_log" 2>&1; then
         if [ -n "$backup_dir" ]; then
             rm -rf "$BLACKBOX_DKG_CLI_DIR"
@@ -1503,7 +1521,7 @@ dkg_manual_hint() {
     step "To set up the DKG node later:"
     echo "      node -v  # must be v$NODE_MAJOR or newer (run: nvm use $NODE_MAJOR)"
     echo "      mkdir -p \"$BLACKBOX_DKG_CLI_DIR\""
-    echo "      npm install --prefix \"$BLACKBOX_DKG_CLI_DIR\" \"$BLACKBOX_DKG_PACKAGE\""
+    echo "      npm install -g --prefix \"$BLACKBOX_DKG_CLI_DIR\" \"$BLACKBOX_DKG_PACKAGE\""
     echo "      export BLACKBOX_DKG_HOME=\"$BLACKBOX_DKG_HOME\""
     echo "      export BLACKBOX_DKG_BIN=\"$BLACKBOX_DKG_BIN\""
     echo "      export BLACKBOX_DKG_PORT=\"$BLACKBOX_DKG_PORT\""
@@ -1563,16 +1581,20 @@ uses_unpaired_shared_dkg_home = uses_shared_dkg_home and (not current_dkg_url or
 uses_legacy_blackbox_dkg_home = current_dkg_home_abs == legacy_blackbox_dkg_home
 current_dkg_bin = str(blackbox.get("dkg_bin") or blackbox.get("dkgBin") or "").strip()
 current_dkg_bin_abs = os.path.abspath(os.path.expanduser(current_dkg_bin)) if current_dkg_bin else ""
-expected_managed_bin = (
-    os.path.join(os.path.dirname(current_dkg_home_abs), "dkg", "node_modules", ".bin", "dkg")
-    if current_dkg_home_abs else ""
+expected_managed_bins = (
+    (
+        os.path.join(os.path.dirname(current_dkg_home_abs), "dkg", "bin", "dkg"),
+        os.path.join(os.path.dirname(current_dkg_home_abs), "dkg", "node_modules", ".bin", "dkg"),
+    )
+    if current_dkg_home_abs
+    else ()
 )
 uses_target_managed_home = current_dkg_home_abs == target_dkg_home_abs
 uses_other_managed_checkout = bool(
     current_dkg_home_abs
     and os.path.basename(current_dkg_home_abs) == ".dkg"
     and current_dkg_home_abs != target_dkg_home_abs
-    and current_dkg_bin_abs == expected_managed_bin
+    and current_dkg_bin_abs in expected_managed_bins
 )
 stale_configured_dkg_home = bool(current_dkg_home_abs) and not os.path.isdir(current_dkg_home_abs)
 stale_configured_dkg_bin = bool(current_dkg_bin_abs) and not os.path.isfile(current_dkg_bin_abs)

--- a/tests/plugins/test_agents_md_context_cap.py
+++ b/tests/plugins/test_agents_md_context_cap.py
@@ -25,7 +25,7 @@ def test_repo_agents_md_loads_whole_at_pinned_cap(monkeypatch):
     # Use the pinned cap, not the machine's live ~/.hermes config, so this guards
     # the repo invariant on any machine / in CI.
     monkeypatch.setattr(
-        "hermes_cli.config.load_config",
+        "hermes_cli.config.load_config_readonly",
         lambda: {"context_file_max_chars": PIN},
     )
 

--- a/tests/plugins/test_blackbox_plugin.py
+++ b/tests/plugins/test_blackbox_plugin.py
@@ -342,6 +342,37 @@ def test_managed_dkg_sync_environment_finds_runtime_without_pid_file(tmp_path, m
     env = cli_mod._dkg_sync_environment(cfg)
 
     assert env["PATH"].split(cli_mod.os.pathsep)[0] == str(node.parent)
+    assert env["npm_config_prefix"] == str(dkg_cli.parent)
+
+
+def test_managed_dkg_sync_environment_pins_private_global_prefix(tmp_path, monkeypatch):
+    prefix = tmp_path / "private-dkg"
+    dkg_bin = prefix / "bin" / "dkg"
+    dkg_bin.parent.mkdir(parents=True)
+    dkg_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    cfg = config_mod.BlackboxConfig(
+        dkg_home=str(tmp_path / "home"), dkg_bin=str(dkg_bin)
+    )
+    monkeypatch.setattr(cli_mod, "_managed_dkg_node_executable", lambda _cfg: None)
+
+    env = cli_mod._dkg_sync_environment(cfg)
+
+    assert env["npm_config_prefix"] == str(prefix)
+
+
+def test_managed_dkg_sync_environment_recognises_legacy_local_layout(
+    tmp_path, monkeypatch
+):
+    prefix = tmp_path / "private-dkg"
+    dkg_bin = prefix / "node_modules" / ".bin" / "dkg"
+    dkg_bin.parent.mkdir(parents=True)
+    dkg_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    cfg = config_mod.BlackboxConfig(
+        dkg_home=str(tmp_path / "home"), dkg_bin=str(dkg_bin)
+    )
+    monkeypatch.setattr(cli_mod, "_managed_dkg_node_executable", lambda _cfg: None)
+
+    assert cli_mod._dkg_sync_environment(cfg)["npm_config_prefix"] == str(prefix)
 
 
 def test_blackbox_sync_require_rules_fails_empty_ruleset(monkeypatch, capsys):

--- a/tests/plugins/test_blackbox_settings.py
+++ b/tests/plugins/test_blackbox_settings.py
@@ -151,7 +151,7 @@ def test_load_config_defaults_to_isolated_blackbox_dkg(monkeypatch, tmp_path):
     cfg = config_mod.load_blackbox_config()
     assert cfg.dkg_url == constants.DEFAULT_DKG_URL
     assert cfg.dkg_home == str(hermes_home / "blackbox" / "dkg")
-    assert cfg.dkg_bin == str(hermes_home / "blackbox" / "dkg-cli" / "node_modules" / ".bin" / "dkg")
+    assert cfg.dkg_bin == str(hermes_home / "blackbox" / "dkg-cli" / "bin" / "dkg")
 
 
 def test_load_config_accepts_blackbox_dkg_overrides(monkeypatch, tmp_path):

--- a/tests/scripts/test_blackbox_dkg_runtime_fingerprint.py
+++ b/tests/scripts/test_blackbox_dkg_runtime_fingerprint.py
@@ -227,6 +227,33 @@ def test_installed_commit_reads_published_npm_build_metadata(tmp_path, capsys):
     assert capsys.readouterr().out.strip() == expected
 
 
+def test_private_global_install_is_fingerprinted_and_reports_commit(tmp_path):
+    cli_dir = tmp_path / "dkg"
+    dkg_home = tmp_path / "home"
+    package = cli_dir / "lib" / "node_modules" / "@origintrail-official" / "dkg"
+    agent = package / "node_modules" / "@origintrail-official" / "dkg-agent"
+    (package / "dist").mkdir(parents=True)
+    (agent / "dist").mkdir(parents=True)
+    (cli_dir / "bin").mkdir(parents=True)
+    dkg_home.mkdir()
+    (package / "package.json").write_text('{"version":"10.0.11"}')
+    (package / "dist" / "cli.js").write_text("export {};\n")
+    expected = "539429d419a01148a974e7db705d6e777eb9eb8f"
+    (package / "build-info.json").write_text(json.dumps({"commit": expected}))
+    (agent / "package.json").write_text('{"version":"10.0.11"}')
+    (agent / "dist" / "agent.js").write_text("export {};\n")
+    (dkg_home / "config.json").write_text("{}\n")
+    dkg_bin = cli_dir / "bin" / "dkg"
+    dkg_bin.write_text("#!/bin/sh\n")
+
+    fingerprint = FINGERPRINTER.compute_fingerprint(
+        cli_dir, dkg_home, Path(sys.executable), dkg_bin
+    )
+
+    assert len(fingerprint) == 64
+    assert FINGERPRINTER.installed_commit(cli_dir) == expected
+
+
 def test_invalid_record_value_fails_closed(tmp_path, capsys):
     marker = tmp_path / "marker"
 

--- a/tests/test_blackbox_dashboard_chat.py
+++ b/tests/test_blackbox_dashboard_chat.py
@@ -9,6 +9,38 @@ from plugins.blackbox import attach
 from plugins.blackbox.dashboard import server
 
 
+@pytest.mark.parametrize(
+    ("reachable", "node_status", "expected_state"),
+    [
+        (False, {}, "offline"),
+        (True, {"autoUpdate": False, "version": "10.0.11"}, "disabled"),
+        (True, {"autoUpdate": True, "version": "10.0.11"}, "checking"),
+        (
+            True,
+            {"autoUpdate": True, "version": "10.0.11", "updateAvailable": False},
+            "current",
+        ),
+        (
+            True,
+            {
+                "autoUpdate": True,
+                "version": "10.0.10",
+                "latestVersion": "10.0.11",
+                "updateAvailable": True,
+            },
+            "available",
+        ),
+    ],
+)
+def test_dkg_update_view_reports_operator_facing_state(
+    reachable, node_status, expected_state
+):
+    view = server._dkg_update_view(node_status, reachable=reachable)
+
+    assert view["state"] == expected_state
+    assert view["current_version"] == node_status.get("version")
+
+
 def test_dashboard_public_graph_uses_vm_verified_ruleset_rows(monkeypatch):
     from plugins.blackbox import audit, config, dkg_client, ruleset
 
@@ -470,6 +502,23 @@ def test_dashboard_refetches_empty_graph_when_first_verified_threats_arrive():
         render_status.index("lastStatus = data;")
     )
     assert 'resetEmptyGraphOnFirstVerifiedThreats("public", previousPublicTotal);' in render_status
+
+
+def test_dashboard_surfaces_dkg_update_status_in_header_and_settings():
+    html = (
+        Path(__file__).resolve().parents[1]
+        / "plugins"
+        / "blackbox"
+        / "dashboard"
+        / "static"
+        / "index.html"
+    ).read_text(encoding="utf-8")
+
+    assert 'id="pill-dkg"' in html
+    assert 'id="set-dkg-update-state"' in html
+    assert 'id="set-dkg-update-help"' in html
+    assert "function renderDkgUpdateStatus(update, reachable)" in html
+    assert 'status.className = "set-dkg-status " + state;' in html
 
 
 @pytest.mark.skip(reason="dashboard never joins private graphs")

--- a/tests/test_blackbox_install_llm_setup.py
+++ b/tests/test_blackbox_install_llm_setup.py
@@ -474,13 +474,13 @@ def test_unix_installer_uses_isolated_blackbox_dkg_node() -> None:
     assert 'BLACKBOX_INSTALL_ROOT="$PWD/agent-blackbox"' in text
     assert 'BLACKBOX_DKG_HOME="$BLACKBOX_INSTALL_ROOT/.dkg"' in text
     assert 'BLACKBOX_DKG_CLI_DIR="$BLACKBOX_INSTALL_ROOT/dkg"' in text
-    assert 'BLACKBOX_DKG_BIN="$BLACKBOX_DKG_CLI_DIR/node_modules/.bin/dkg"' in text
+    assert 'BLACKBOX_DKG_BIN="$BLACKBOX_DKG_CLI_DIR/bin/dkg"' in text
     assert (
         'BLACKBOX_DKG_PACKAGE="${BLACKBOX_DKG_PACKAGE:-'
         '@origintrail-official/dkg@latest}"'
     ) in text
     assert 'BLACKBOX_DKG_DAEMON_URL="http://127.0.0.1:$BLACKBOX_DKG_PORT"' in text
-    assert 'npm install --prefix "$BLACKBOX_DKG_CLI_DIR"' in text
+    assert 'npm install -g --prefix "$BLACKBOX_DKG_CLI_DIR"' in text
     assert '--prefer-online' in text
     assert "BLACKBOX_DKG_REPO_URL" not in text
     assert "corepack pnpm" not in text
@@ -497,8 +497,7 @@ def test_unix_installer_uses_isolated_blackbox_dkg_node() -> None:
     assert "migrate_legacy_blackbox_dkg_home" in text
     assert 'blackbox["dkg_home"] = dkg_home' in text
     assert 'blackbox["dkg_bin"] = dkg_bin' in text
-    assert "npm i -g" not in text
-    assert "npm install -g" not in text
+    assert 'npm_config_prefix="$BLACKBOX_DKG_CLI_DIR"' in text
     assert '"dkg_url": "http://127.0.0.1:9200"' not in text
 
 
@@ -712,10 +711,10 @@ def test_windows_installer_uses_isolated_blackbox_dkg_node() -> None:
     assert "$DkgStoreUrl" in text
     assert '$DkgHome     = Join-Path $DefaultRepoDir ".dkg"' in text
     assert '$DkgCliDir   = Join-Path $DefaultRepoDir "dkg"' in text
-    assert r'$DkgBin      = Join-Path $DkgCliDir "node_modules\.bin\dkg.cmd"' in text
+    assert r'$DkgBin      = Join-Path $DkgCliDir "dkg.cmd"' in text
     assert "@origintrail-official/dkg@latest" in text
     assert '$DkgDaemonUrl = "http://127.0.0.1:$DkgPort"' in text
-    assert "npm install --prefix $DkgCliDir --prefer-online $DkgPackage" in text
+    assert "npm install -g --prefix $DkgCliDir --prefer-online $DkgPackage" in text
     assert "BLACKBOX_DKG_REPO_URL" not in text
     assert "corepack pnpm" not in text
     assert "Ensure-BlackboxDkgConfig" in text
@@ -734,8 +733,7 @@ def test_windows_installer_uses_isolated_blackbox_dkg_node() -> None:
     assert "Move-LegacyBlackboxDkgHome" in text
     assert 'blackbox["dkg_home"] = dkg_home' in text
     assert 'blackbox["dkg_bin"] = dkg_bin' in text
-    assert "npm i -g" not in text
-    assert "npm install -g" not in text
+    assert '$env:npm_config_prefix = $DkgCliDir' in text
     assert '"dkg_url": "http://127.0.0.1:9200"' not in text
 
 
@@ -790,6 +788,67 @@ def test_dkg_config_writer_leaves_subscriptions_to_the_dkg_api(tmp_path: Path) -
         "backend": "blazegraph",
         "options": {"url": BLAZEGRAPH_URL, "managedByDkg": True, "timeout": 900000},
     }
+
+
+@pytest.mark.parametrize("initial", [None, {"enabled": False}])
+def test_dkg_config_writer_enables_managed_npm_updates(tmp_path: Path, initial) -> None:
+    home = tmp_path / "dkg"
+    home.mkdir()
+    config = home / "config.json"
+    if initial is not None:
+        config.write_text(json.dumps({"autoUpdate": initial}), encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _extract_unix_config_writer(),
+            str(home),
+            "9320",
+            "blazegraph",
+            BLAZEGRAPH_URL,
+            "true",
+            "umanitek/blackbox-threats-staging",
+        ],
+        check=True,
+    )
+
+    assert json.loads(config.read_text())["autoUpdate"] == {
+        "enabled": True,
+        "source": "npm",
+        "channel": "mainnet",
+        "allowPrerelease": False,
+    }
+
+
+def test_dkg_config_writer_preserves_custom_auto_update_opt_out(tmp_path: Path) -> None:
+    home = tmp_path / "dkg"
+    home.mkdir()
+    config = home / "config.json"
+    config.write_text(
+        json.dumps({"autoUpdate": {"enabled": False, "checkIntervalMinutes": 60}}),
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _extract_unix_config_writer(),
+            str(home),
+            "9320",
+            "blazegraph",
+            BLAZEGRAPH_URL,
+            "true",
+            "umanitek/blackbox-threats-staging",
+        ],
+        check=True,
+    )
+
+    auto_update = json.loads(config.read_text())["autoUpdate"]
+    assert auto_update["enabled"] is False
+    assert auto_update["checkIntervalMinutes"] == 60
+    assert auto_update["source"] == "npm"
 
 def test_dkg_config_writer_reports_only_real_runtime_changes(tmp_path: Path) -> None:
     home = tmp_path / "dkg"
@@ -1384,11 +1443,17 @@ def test_blazegraph_helper_sizes_heap_and_preserves_undersized_store(tmp_path: P
     assert json.loads(completed.stdout)["url"] == calls[3]
 
 
-def test_blazegraph_helper_uses_dkg_store_health_check(tmp_path: Path) -> None:
+@pytest.mark.parametrize("private_global", [False, True])
+def test_blazegraph_helper_uses_dkg_store_health_check(
+    tmp_path: Path, private_global: bool
+) -> None:
     node = shutil.which("node")
     if not node:
         pytest.skip("Node.js is not installed")
-    cli = tmp_path / "node_modules" / "@origintrail-official" / "dkg"
+    cli = tmp_path
+    if private_global:
+        cli = cli / "lib"
+    cli = cli / "node_modules" / "@origintrail-official" / "dkg"
     module = cli / "dist" / "daemon" / "store-health-check.js"
     module.parent.mkdir(parents=True)
     (cli / "package.json").write_text('{"type":"module"}', encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes Blackbox-managed DKG nodes not receiving upstream npm releases automatically.

Blackbox previously wrote `autoUpdate.enabled: false`. Its DKG package also used a prefix-local npm layout, while DKG's official Edge updater deliberately runs `npm install -g`. Enabling the flag alone would therefore update the wrong prefix or fail on system permissions.

This change:

- installs DKG as a private npm-global package inside the Blackbox checkout;
- enables the official stable `mainnet` npm update channel;
- passes the private npm prefix through installer, daemon, sync, and restart paths;
- migrates the exact legacy `{"enabled": false}` installer default while preserving customized operator opt-outs;
- supports both legacy and private-global layouts during migration and runtime verification;
- keeps DKG's native self-check, rollback marker, rollout jitter, and supervised restart behavior;
- exposes DKG version/update state in the desktop header and responsive Settings UI;
- updates Unix, Windows, manual-install docs, Blazegraph helpers, runtime fingerprinting, and contributor mapping.

## Root cause

```mermaid
flowchart LR
    A["Blackbox installer"] --> B["autoUpdate.enabled = false"]
    A --> C["npm install --prefix dkg"]
    D["Official DKG Edge updater"] --> E["npm install -g"]
    B --> F["No scheduled update"]
    C -. "different layout/prefix" .-> E
    E --> G["System prefix or permission failure"]
```

## Fixed lifecycle

```mermaid
sequenceDiagram
    participant BB as Blackbox
    participant DKG as DKG daemon
    participant NPM as npm mainnet channel
    participant SUP as DKG supervisor

    BB->>DKG: Start with DKG_HOME + private npm_config_prefix
    DKG->>NPM: Poll stable mainnet dist-tag
    NPM-->>DKG: New version available
    DKG->>DKG: npm install -g into private prefix
    DKG->>DKG: Verify installed CLI version
    alt self-check passes
        DKG->>SUP: Exit for supervised restart
        SUP->>DKG: Start new version from same private prefix
    else install or self-check fails
        DKG->>DKG: Restore recorded rollback target
    end
```

## Verification

- `ruff check` on all changed Python files: pass
- installer/fingerprint/settings suite: **108 passed, 1 skipped**
- focused migration/layout/update suite: **17 passed**
- dashboard status/UI suite: **31 passed, 5 skipped**
- shell syntax, Node syntax, and `git diff --check`: pass
- real manual upgrade in a temporary private prefix: **DKG 10.0.9 to 10.0.11**, self-check passed
- real daemon-polled upgrade: detected `10.0.11`, installed it, exited, and supervisor restarted the node as `v10.0.11`
- runtime fingerprint and build commit resolved successfully after the live upgrade
- npm's system prefix remained unchanged

## Compatibility

Existing local-layout installs are recognized during migration. The installer creates the new private-global entry point and rewrites only Blackbox-managed paths. A customized `autoUpdate.enabled: false` configuration with additional operator settings remains disabled.