### PR TITLE
fix(blackbox): show live durable sync progress

### DIFF
--- a/plugins/blackbox/dashboard/server.py
+++ b/plugins/blackbox/dashboard/server.py
@@ -59,6 +59,57 @@ def _dkg_durable_progress(dkg_home: str, context_graph_id: str) -> Dict[str, Any
     return read_durable_progress(dkg_home, context_graph_id)
 
 
+def _activity_transfer_state(
+    authoritative_sync: Dict[str, Any],
+    catchup: Dict[str, Any],
+    durable_progress: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build the transfer view used by the dashboard activity panel.
+
+    A managed DKG restart can terminate the source-pinned HTTP request while
+    its durable replacement job immediately resumes from the checkpoint. Keep
+    the persisted authoritative result intact for diagnostics, but render the
+    live daemon job and its current durable offset instead of the old failure.
+    """
+    transfer = {**authoritative_sync, **durable_progress}
+    try:
+        previous_expected = int(authoritative_sync.get("expected_triples") or 0)
+        current_expected = int(durable_progress.get("expected_triples") or 0)
+    except (TypeError, ValueError):
+        previous_expected = 0
+        current_expected = 0
+    if previous_expected > 0 and previous_expected == current_expected:
+        for key in ("current_triples", "safe_current_triples"):
+            try:
+                transfer[key] = max(
+                    int(authoritative_sync.get(key) or 0),
+                    int(durable_progress.get(key) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+        safe_current = int(transfer.get("safe_current_triples") or 0)
+        current = max(safe_current, int(transfer.get("current_triples") or 0))
+        transfer["current_triples"] = min(current, current_expected)
+        transfer["progress_percent"] = round(
+            (transfer["current_triples"] / current_expected) * 100, 1
+        )
+        transfer["snapshot_complete"] = safe_current >= current_expected
+    if str(transfer.get("status") or "").lower() == "running":
+        return transfer
+    if str(catchup.get("status") or "").lower() != "running":
+        return transfer
+
+    transfer.update(
+        status="running",
+        phase="recovering-verifiable-memory",
+        started_at=catchup.get("startedAt"),
+        updated_at=durable_progress.get("updated_at"),
+    )
+    transfer.pop("error", None)
+    transfer.pop("retryable", None)
+    return transfer
+
+
 def _blackbox_runtime_argv(port: int = _BLACKBOX_RUNTIME_PORT) -> List[str]:
     """Command for the dashboard-owned, profile-isolated Agent Blackbox backend."""
     return [
@@ -533,6 +584,47 @@ def _sync_activity(
         or ""
     )
 
+    # The foreground command can reach its own wait deadline while the local
+    # DKG scheduler still has the request queued behind reconciliation.  That
+    # is durable, retryable admission pressure, not a terminal graph failure.
+    # Preserve the last verified cache and show the waiting state even if the
+    # daemon's generic job record still says ``failed``.
+    if (
+        node_reachable
+        and transfer_status == "waiting"
+        and phase == "waiting-for-dkg-capacity"
+    ):
+        progress.update(
+            status="waiting",
+            phase=phase,
+            label="Waiting for local DKG sync capacity",
+            detail=(
+                "Another verified graph transfer is using the local DKG sync "
+                "slot. Blackbox will retry from its durable checkpoint."
+            ),
+            started_at=transfer.get("started_at"),
+            updated_at=transfer.get("updated_at"),
+        )
+        if expected_triples > 0:
+            bounded_triples = max(0, min(current_triples, expected_triples))
+            progress.update(
+                detail=(
+                    f"{bounded_triples:,} of {expected_triples:,} graph triples "
+                    "are checkpointed. Blackbox is waiting for the local DKG "
+                    "sync slot and will resume automatically."
+                ),
+                current=bounded_triples,
+                expected=expected_triples,
+                percent=round((bounded_triples / expected_triples) * 100, 1),
+                indeterminate=False,
+            )
+        elif public > 0:
+            progress["detail"] = (
+                f"{public:,} verified public threats remain available while "
+                "Blackbox waits for the local DKG sync slot."
+            )
+        return progress
+
     # The source-pinned transfer is the authoritative result for this graph.
     # A generic catch-up job may still retain an older failure after that
     # transfer completed successfully; do not turn verified local data into a
@@ -557,7 +649,11 @@ def _sync_activity(
     # capacity for this pass; it is not a corrupt graph or a terminal client
     # error. Keep the full response in sync-state/logs for diagnosis, but show
     # users the automatic durable-resume behavior instead of raw HTTP JSON.
-    if node_reachable and _is_retryable_durable_catchup_error(error):
+    if (
+        node_reachable
+        and catchup_status not in {"queued", "running"}
+        and _is_retryable_durable_catchup_error(error)
+    ):
         detail = (
             "The sync-capable publisher is temporarily busy or unavailable. "
             "Blackbox will retry automatically and resume from its durable checkpoint."
@@ -1440,11 +1536,18 @@ def create_app(*, manage_blackbox: bool = False):
         authoritative_sync = sync_state.read_for_graph(cfg.context_graph_id)
         authoritative_running = authoritative_sync.get("status") == "running"
         authoritative_done = authoritative_sync.get("status") == "done"
+        durable_progress: Dict[str, Any] = {}
+        if authoritative_running or node_catchup_state.lower() == "running":
+            durable_progress = _dkg_durable_progress(
+                cfg.dkg_home, cfg.context_graph_id
+            )
+        activity_transfer = _activity_transfer_state(
+            authoritative_sync,
+            catchup,
+            durable_progress,
+        )
         if authoritative_running:
-            authoritative_sync = {
-                **authoritative_sync,
-                **_dkg_durable_progress(cfg.dkg_home, cfg.context_graph_id),
-            }
+            authoritative_sync = dict(activity_transfer)
         # This count is measured from locally committed rows and can advance
         # ahead of the materialized ruleset cache during a large snapshot.
         if authoritative_running:
@@ -1489,13 +1592,13 @@ def create_app(*, manage_blackbox: bool = False):
             node_reachable=bool(g["node_reachable"]),
             catchup=catchup,
             connection=connection,
-            transfer=authoritative_sync,
+            transfer=activity_transfer,
         )
         blackbox_health = _blackbox_sync_health(
             public=public,
             sync_interval=cfg.sync_interval,
             activity=activity,
-            transfer=authoritative_sync,
+            transfer=activity_transfer,
             node_reachable=bool(g["node_reachable"]),
         )
         if activity["status"] in {"running", "waiting"}:

--- a/plugins/blackbox/dkg_progress.py
+++ b/plugins/blackbox/dkg_progress.py
@@ -71,19 +71,56 @@ def read_durable_progress(
         return {}
 
     matches = []
+    selected_expected = 0
+    selected_safe = 0
+    selected_raw = 0
     for match in _DURABLE_PROGRESS_RE.finditer(text):
         if match.group("graph") != context_graph_id:
             continue
+        previous = int(match.group("previous"))
+        current = int(match.group("current"))
+        expected = int(match.group("expected"))
+        raw = int(match.group("raw"))
+        if not matches:
+            matches = [match]
+            selected_expected = expected
+            selected_safe = current
+            selected_raw = raw
+            continue
+
+        if expected != selected_expected:
+            # Exact VM recovery emits its own much smaller rootless manifest
+            # while the parent snapshot is still incomplete. If that entire
+            # child window fits behind the parent prefix already received, it
+            # cannot be a replacement snapshot and must not reset dashboard
+            # progress to a misleading 100%.
+            parent_received = max(selected_safe, selected_raw)
+            nested_repair = (
+                selected_safe < selected_expected
+                and expected <= parent_received
+            )
+            if nested_repair:
+                continue
+            matches = [match]
+            selected_expected = expected
+            selected_safe = current
+            selected_raw = raw
+            continue
+
         # A previous implementation reset only on 0->0. Real bounded passes
         # begin 0->positive, so retaining earlier matches made a restarted
         # transfer look permanently 100% complete.
-        if int(match.group("previous")) == 0:
+        if previous == 0 and selected_safe >= selected_expected:
             matches = []
+            selected_safe = 0
+            selected_raw = 0
         matches.append(match)
+        selected_safe = max(selected_safe, current)
+        selected_raw = max(selected_raw, raw)
     if not matches:
         return {}
 
-    expected = int(matches[-1].group("expected"))
+    expected = selected_expected
     if expected <= 0:
         return {}
     same_manifest = [

--- a/plugins/blackbox/sync_state.py
+++ b/plugins/blackbox/sync_state.py
@@ -13,6 +13,16 @@ import psutil
 from . import constants
 
 _STALE_RUNNING_SECONDS = 3_600
+_ACTIVE_STATUSES = {"running", "waiting"}
+_PROGRESS_KEYS = (
+    "public_entries",
+    "expected_public_entries",
+    "community_entries",
+    "current_triples",
+    "safe_current_triples",
+    "expected_triples",
+    "inserted_durable_triples",
+)
 
 
 def _pid_is_alive(pid: Any) -> bool:
@@ -45,11 +55,11 @@ def write(status: str, **details: Any) -> Dict[str, Any]:
         "pid": os.getpid(),
         **details,
     }
-    if status == "running" and previous.get("status") == "running":
-        for key in ("public_entries", "expected_public_entries", "community_entries"):
+    if status in _ACTIVE_STATUSES and previous.get("status") in _ACTIVE_STATUSES:
+        for key in _PROGRESS_KEYS:
             if key not in details and key in previous:
                 state[key] = previous[key]
-    if status == "running" and previous.get("status") != "running":
+    if status in _ACTIVE_STATUSES and previous.get("status") not in _ACTIVE_STATUSES:
         state["started_at"] = now
     tmp = path.with_suffix(f".tmp-{os.getpid()}")
     tmp.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")

--- a/tests/plugins/test_blackbox_dashboard_server.py
+++ b/tests/plugins/test_blackbox_dashboard_server.py
@@ -435,6 +435,27 @@ def test_dkg_durable_progress_marks_safe_manifest_complete(tmp_path):
     ] is True
 
 
+def test_dkg_durable_progress_ignores_nested_exact_repair_manifest(tmp_path):
+    graph = "0x37b1/agent-blackbox-vm"
+    (tmp_path / "daemon.log").write_text(
+        "\n".join(
+            [
+                f'Rootless durable progress for "{graph}": 5 complete graph(s), safe offset 129775->169332 of 6357721 (raw 179951)',
+                f'Rootless durable progress for "{graph}": 1 complete graph(s), safe offset 0->11000 of 11000 (raw 11000)',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert server._dkg_durable_progress(str(tmp_path), graph) == {
+        "current_triples": 179_951,
+        "safe_current_triples": 169_332,
+        "expected_triples": 6_357_721,
+        "progress_percent": 2.8,
+        "snapshot_complete": False,
+    }
+
+
 def test_sync_activity_reports_durable_download_percentage():
     activity = server._sync_activity(
         public=66_000,

--- a/tests/test_blackbox_dashboard_chat.py
+++ b/tests/test_blackbox_dashboard_chat.py
@@ -162,6 +162,33 @@ def test_running_sync_state_keeps_latest_committed_count(monkeypatch, tmp_path):
     assert state["public_entries"] == 460_000
 
 
+def test_waiting_sync_state_preserves_durable_progress(monkeypatch, tmp_path):
+    from plugins.blackbox import sync_state
+
+    state_path = tmp_path / "authoritative-sync.json"
+    monkeypatch.setattr(sync_state, "_path", lambda: state_path)
+
+    sync_state.write(
+        "running",
+        phase="recovering-verifiable-memory",
+        public_entries=362_000,
+        current_triples=3_584,
+        expected_triples=8_000,
+    )
+    sync_state.write(
+        "waiting",
+        phase="waiting-for-dkg-capacity",
+        error="Sync backpressure rejected",
+        retryable=True,
+    )
+
+    state = sync_state.read()
+    assert state["status"] == "waiting"
+    assert state["public_entries"] == 362_000
+    assert state["current_triples"] == 3_584
+    assert state["expected_triples"] == 8_000
+
+
 def test_active_catchup_supersedes_older_authoritative_failure():
     activity = server._sync_activity(
         public=0,
@@ -183,6 +210,97 @@ def test_active_catchup_supersedes_older_authoritative_failure():
     assert activity["phase"] == "network-catchup"
     assert activity["label"] == "Fetching graph snapshot"
     assert "503" not in activity["detail"]
+
+
+def test_active_dkg_catchup_renders_durable_progress_over_old_failure():
+    authoritative = {
+        "status": "failed",
+        "updated_at": 100.0,
+        "error": "older source-pinned transport failure",
+    }
+    transfer = server._activity_transfer_state(
+        authoritative,
+        {"status": "running", "startedAt": 200.0},
+        {
+            "current_triples": 136_479,
+            "safe_current_triples": 129_775,
+            "expected_triples": 6_117_721,
+            "progress_percent": 2.2,
+            "snapshot_complete": False,
+        },
+    )
+
+    activity = server._sync_activity(
+        public=367_000,
+        community=0,
+        node_reachable=True,
+        catchup={"status": "running", "startedAt": 200.0},
+        connection={},
+        transfer=transfer,
+    )
+
+    assert authoritative["status"] == "failed"
+    assert transfer["status"] == "running"
+    assert "error" not in transfer
+    assert activity["status"] == "running"
+    assert activity["label"] == "Receiving publisher VM"
+    assert activity["current"] == 136_479
+    assert activity["expected"] == 6_117_721
+    assert activity["percent"] == 2.2
+    assert activity["indeterminate"] is False
+
+
+def test_active_dkg_catchup_does_not_regress_same_manifest_checkpoint():
+    transfer = server._activity_transfer_state(
+        {
+            "status": "running",
+            "current_triples": 179_951,
+            "safe_current_triples": 169_332,
+            "expected_triples": 6_357_721,
+        },
+        {"status": "running", "startedAt": 200.0},
+        {
+            "current_triples": 57_088,
+            "safe_current_triples": 51_642,
+            "expected_triples": 6_357_721,
+            "progress_percent": 0.9,
+            "snapshot_complete": False,
+        },
+    )
+
+    assert transfer["current_triples"] == 179_951
+    assert transfer["safe_current_triples"] == 169_332
+    assert transfer["expected_triples"] == 6_357_721
+    assert transfer["progress_percent"] == 2.8
+    assert transfer["snapshot_complete"] is False
+
+
+def test_local_backpressure_deadline_remains_waiting_in_dashboard():
+    activity = server._sync_activity(
+        public=362_000,
+        community=0,
+        node_reachable=True,
+        catchup={"status": "failed", "error": "older generic failure"},
+        connection={"state": "syncing", "updated_at": 200.0},
+        transfer={
+            "status": "waiting",
+            "phase": "waiting-for-dkg-capacity",
+            "started_at": 100.0,
+            "updated_at": 200.0,
+            "public_entries": 362_000,
+            "current_triples": 3_584,
+            "expected_triples": 8_000,
+            "retryable": True,
+            "error": "Sync backpressure rejected (global inflight=1/1)",
+        },
+    )
+
+    assert activity["status"] == "waiting"
+    assert activity["phase"] == "waiting-for-dkg-capacity"
+    assert activity["label"] == "Waiting for local DKG sync capacity"
+    assert activity["current"] == 3_584
+    assert activity["expected"] == 8_000
+    assert "failed" not in activity["detail"].lower()
 
 
 def test_dashboard_automatic_sync_runs_canonical_verified_cli(monkeypatch):


### PR DESCRIPTION
## Summary

Fix Blackbox dashboard sync reporting so it follows the durable parent snapshot across retries, fallback catch-up, and bounded exact-repair work.

The dashboard now:

- displays the live `current / expected` durable checkpoint while DKG fallback catch-up is running
- keeps progress visible when an older source-pinned request has exited or failed
- preserves progress across `running` and `waiting` transitions
- prevents same-manifest retries from moving the progress bar backward
- prevents small exact-repair submanifests from masquerading as a completed parent snapshot
- reports Blackbox health as `updating` while verified graph recovery is active

## User-visible problem

The node could be receiving and checkpointing millions of graph triples while the dashboard continued to show only the cached verified-threat count. During exact recovery, the panel could also switch from the multi-million-triple parent snapshot to a small bounded window such as `11,000 / 11,000` and incorrectly render **Finalizing verified snapshot**.

Observed symptoms included:

- verified-threat count appeared static even though daemon checkpoints advanced
- an older failed source-pinned request covered a newer live DKG fallback job
- retry windows made displayed progress regress
- exact VM repair windows appeared as false `100%` snapshot completion

The verified cache remained usable throughout; this PR fixes the monitoring/state-composition layer rather than changing DKG transport or storage behavior.

## Root causes

1. `graph-status` merged durable log progress only when the source-pinned Blackbox transfer had `status=running`.
2. DKG can continue through a replacement/native catch-up job after that source-pinned HTTP request exits.
3. Same-manifest retry windows could return a smaller local offset than the persisted safe checkpoint.
4. Exact VM recovery emits a nested rootless manifest for the same Context Graph. The parser treated every `0 -> positive` window as a replacement snapshot, even when the entire child window was already behind the incomplete parent prefix.
5. `waiting` state writes did not retain all durable progress fields.

## Sequence: failure before this change

```mermaid
sequenceDiagram
    participant CLI as Blackbox source-pinned sync
    participant DKG as Managed DKG daemon
    participant State as Blackbox sync state
    participant UI as Dashboard

    CLI->>DKG: Start curator-pinned catch-up
    DKG-->>CLI: Transport closes or request deadline fires
    CLI->>State: Persist failed source-pinned result
    Note over DKG: Native durable catch-up keeps running
    DKG->>DKG: Advance safe checkpoint
    UI->>State: Read old failed result
    UI-->>UI: Show stale cached count or failure
```

## Sequence: live progress composition after this change

```mermaid
sequenceDiagram
    participant UI as Blackbox dashboard
    participant State as Blackbox sync state
    participant DKG as DKG catch-up status
    participant Log as Durable progress log
    participant Merge as Activity-state merger

    UI->>State: Read persisted source-pinned result
    UI->>DKG: Read current fallback catch-up job
    UI->>Log: Read parent snapshot checkpoint
    UI->>Merge: Compose authoritative, catch-up, and durable state

    alt source-pinned request is running
        Merge->>Merge: Merge durable checkpoint monotonically
    else fallback DKG catch-up is running
        Merge->>Merge: Preserve diagnostic failure separately
        Merge->>Merge: Render replacement job as active
    end

    Merge-->>UI: current, expected, percent, updating health
```

The persisted authoritative result is not rewritten for presentation. It remains available under `sync_progress.authoritative`; only the activity view is synthesized from the newer live job.

## Sequence: parent snapshot versus nested exact repair

```mermaid
sequenceDiagram
    participant DKG as DKG durable sync
    participant Log as daemon.log
    participant Reader as Durable progress reader
    participant UI as Dashboard

    DKG->>Log: Parent checkpoint 169,332 / 6,357,721
    DKG->>Log: Exact repair 11,000 / 11,000
    Reader->>Reader: Compare child expected with parent received prefix

    alt child fits entirely behind incomplete parent prefix
        Reader->>Reader: Keep parent snapshot active
        Reader-->>UI: 169,332 / 6,357,721
    else manifest is a genuine replacement
        Reader->>Reader: Start the new progress window
        Reader-->>UI: New current / expected
    end
```

## Behavioral invariants

- Verified queryable threats remain available while a replacement snapshot is being recovered.
- Progress for the same manifest is monotonic.
- A nested repair cannot turn an incomplete parent into a false `100%` result.
- A genuinely different parent manifest can still replace the previous progress window.
- Terminal source-pinned evidence remains visible for diagnostics.
- No additional DKG writes, subscriptions, retries, or network requests are introduced by the UI merge.

## Implementation

- `dashboard/server.py`
  - composes a separate activity transfer from persisted state, live DKG status, and durable progress
  - preserves the authoritative diagnostic result
  - renders retryable capacity waits with checkpoint information
  - feeds the composed live state into dashboard health
- `dkg_progress.py`
  - retains the incomplete parent when a smaller exact-repair window fits behind the received prefix
  - preserves reset behavior for genuinely new snapshots
- `sync_state.py`
  - preserves public and durable progress fields across active `running` / `waiting` transitions
- regression tests cover fallback catch-up, monotonic retries, waiting-state preservation, and nested repair manifests

## Validation

```text
pytest -q tests/test_blackbox_dashboard_chat.py tests/plugins/test_blackbox_dashboard_server.py
72 passed, 5 skipped
```

Live verification on the Blackbox-owned node:

- parent snapshot displayed as `225,184 / 6,357,721`, then `385,826 / 6,357,721`
- dashboard percentage advanced from `3.5%` to `6.1%`
- verified cached threats remained queryable and continued increasing
- bounded `11,000 / 11,000` exact repair no longer replaced the parent progress bar

## Scope and review focus

This PR changes five Blackbox dashboard/progress files only. It does **not** change DKG runtime code, node configuration, sync concurrency, installers, storage, or transport timeouts.

Suggested review focus:

1. whether the parent-versus-child manifest selection preserves all legitimate reset cases
2. whether keeping the persisted authoritative failure separate from the synthesized activity view is the right API contract
3. whether `running` / `waiting` progress preservation covers every active transition without retaining terminal state accidentally
