### PR TITLE
fix(blackbox): apply effective Blazegraph heap without replacing stores

### DIFF
--- a/scripts/blackbox-blazegraph.mjs
+++ b/scripts/blackbox-blazegraph.mjs
@@ -8,6 +8,14 @@ import { pathToFileURL } from 'node:url';
 const BLACKBOX_BLAZEGRAPH_JAVA_OPTS = '-Xms512m -Xmx4g';
 const BLACKBOX_BLAZEGRAPH_CPUS = '4';
 const MINIMUM_BLAZEGRAPH_HEAP_BYTES = 4 * 1024 * 1024 * 1024;
+const EFFECTIVE_HEAP_MARKER = 'blackbox-effective-blazegraph-heap';
+const LEGACY_HEAP_PATCH = [
+  'set -eu',
+  'setenv=/opt/tomcat/bin/setenv.sh',
+  'test -f "$setenv"',
+  'cp "$setenv" "$setenv.blackbox-pre-4g"',
+  `printf '\\n# ${EFFECTIVE_HEAP_MARKER}\\nexport JAVA_OPTS="${BLACKBOX_BLAZEGRAPH_JAVA_OPTS}"\\n' >> "$setenv"`,
+];
 
 function fail(message) {
   process.stderr.write(`Blazegraph setup failed: ${message}\n`);
@@ -172,33 +180,38 @@ function heapBytes(javaOpts) {
   return Number(match[1]) * units[match[2].toLowerCase()];
 }
 
-function javaOptsFromInspect(stdout) {
+function containerFromInspect(stdout) {
   try {
     const containers = JSON.parse(stdout);
-    const env = containers?.[0]?.Config?.Env;
-    if (!Array.isArray(env)) return '';
-    const entry = env.find((value) => String(value).startsWith('JAVA_OPTS='));
-    return entry ? String(entry).slice('JAVA_OPTS='.length) : '';
+    return containers?.[0] && typeof containers[0] === 'object' ? containers[0] : undefined;
   } catch {
-    return '';
+    return undefined;
   }
 }
 
-function backupContainerName(name) {
-  return `${name}-pre-4g-${Date.now()}`;
+function envFromInspect(container, key) {
+  const env = container?.Config?.Env;
+  if (!Array.isArray(env)) return '';
+  const prefix = `${key}=`;
+  const entry = env.find((value) => String(value).startsWith(prefix));
+  return entry ? String(entry).slice(prefix.length) : '';
+}
+
+function isPinnedIslandoraBlazegraph(container) {
+  return String(container?.Config?.Image || '').startsWith('islandora/blazegraph:');
 }
 
 function blackboxDockerRunner(log) {
   return {
     async run(args, opts) {
-      if (args[0] === 'run' && !args.some((arg) => String(arg).startsWith('JAVA_OPTS='))) {
+      if (args[0] === 'run' && !args.some((arg) => String(arg).startsWith('TOMCAT_JAVA_OPTS='))) {
         return runDocker(
           [
             'run',
             '--cpus',
             BLACKBOX_BLAZEGRAPH_CPUS,
             '-e',
-            `JAVA_OPTS=${BLACKBOX_BLAZEGRAPH_JAVA_OPTS}`,
+            `TOMCAT_JAVA_OPTS=${BLACKBOX_BLAZEGRAPH_JAVA_OPTS}`,
             ...args.slice(1),
           ],
           opts,
@@ -208,7 +221,8 @@ function blackboxDockerRunner(log) {
       const result = await runDocker([...args], opts);
       if (args[0] !== 'inspect' || result.exitCode !== 0) return result;
 
-      const javaOpts = javaOptsFromInspect(result.stdout);
+      const container = containerFromInspect(result.stdout);
+      const javaOpts = envFromInspect(container, 'TOMCAT_JAVA_OPTS');
       if (heapBytes(javaOpts) >= MINIMUM_BLAZEGRAPH_HEAP_BYTES) {
         const name = String(args[1] || 'dkg-blazegraph');
         const limited = await runDocker(
@@ -222,18 +236,57 @@ function blackboxDockerRunner(log) {
       }
 
       const name = String(args[1] || 'dkg-blazegraph');
-      const backup = backupContainerName(name);
-      log(`  Existing container "${name}" uses ${javaOpts || 'the image-default heap'}; replacing it with a 4 GB instance.`);
-      const stopped = await runDocker(['stop', name], { timeoutMs: 30_000 });
-      if (stopped.exitCode !== 0) {
-        throw new Error(`Could not stop undersized Blazegraph container "${name}": ${stopped.stderr.trim()}`);
+      if (!isPinnedIslandoraBlazegraph(container)) {
+        throw new Error(
+          `Existing Blazegraph container "${name}" does not expose a 4 GB effective Tomcat heap `
+          + `and uses unsupported image "${container?.Config?.Image || 'unknown'}". `
+          + 'Refusing to replace it because its local graph data may not be mounted durably.',
+        );
       }
-      const renamed = await runDocker(['rename', name, backup], { timeoutMs: 10_000 });
-      if (renamed.exitCode !== 0) {
-        throw new Error(`Could not preserve undersized Blazegraph container "${name}": ${renamed.stderr.trim()}`);
+
+      if (container?.State?.Running !== true) {
+        // The DKG provisioner will start stopped containers and inspect them again.
+        // Repair only after that start so docker exec can update the image startup hook.
+        return result;
       }
-      log(`  Preserved the old local store as stopped container "${backup}".`);
-      return { stdout: '', stderr: 'container migrated to a recoverable backup', exitCode: 1 };
+
+      const marker = await runDocker([
+        'exec', '--user', '0', name, 'sh', '-c',
+        `grep -Fq '${EFFECTIVE_HEAP_MARKER}' /opt/tomcat/bin/setenv.sh`,
+      ], { timeoutMs: 10_000 });
+      if (marker.exitCode !== 0) {
+        log(
+          `  Existing container "${name}" uses ${javaOpts || 'the image-default Tomcat heap'}; `
+          + 'repairing it in place with a 4 GB heap while preserving /data.',
+        );
+        const patched = await runDocker(
+          ['exec', '--user', '0', name, 'sh', '-c', LEGACY_HEAP_PATCH.join('; ')],
+          { timeoutMs: 10_000 },
+        );
+        if (patched.exitCode !== 0) {
+          throw new Error(
+            `Could not repair the effective Blazegraph heap in container "${name}": `
+            + `${patched.stderr.trim() || 'startup hook update failed'}. `
+            + 'The existing container and graph data were left in place.',
+          );
+        }
+        const restarted = await runDocker(['restart', name], { timeoutMs: 120_000 });
+        if (restarted.exitCode !== 0) {
+          throw new Error(
+            `Could not restart Blazegraph container "${name}" after applying the 4 GB heap: `
+            + `${restarted.stderr.trim() || 'docker restart failed'}`,
+          );
+        }
+      }
+
+      const limited = await runDocker(
+        ['update', '--cpus', BLACKBOX_BLAZEGRAPH_CPUS, name],
+        { timeoutMs: 10_000 },
+      );
+      if (limited.exitCode !== 0) {
+        throw new Error(`Could not apply the Blackbox CPU limit to "${name}": ${limited.stderr.trim()}`);
+      }
+      return result;
     },
   };
 }

--- a/tests/test_blackbox_install_llm_setup.py
+++ b/tests/test_blackbox_install_llm_setup.py
@@ -1336,7 +1336,7 @@ def test_blazegraph_helper_uses_built_dkg_provisioner(tmp_path: Path) -> None:
     }
 
 
-def test_blazegraph_helper_sizes_heap_and_preserves_undersized_store(tmp_path: Path) -> None:
+def test_blazegraph_helper_repairs_legacy_heap_in_place_and_preserves_store(tmp_path: Path) -> None:
     node = shutil.which("node")
     if not node:
         pytest.skip("Node.js is not installed")
@@ -1347,9 +1347,8 @@ def test_blazegraph_helper_sizes_heap_and_preserves_undersized_store(tmp_path: P
     module.write_text(
         "export async function provisionBlazegraphDocker(options) {\n"
         "  const inspected = await options.docker.run(['inspect', 'dkg-blazegraph-test']);\n"
-        "  if (inspected.exitCode === 0) throw new Error('undersized container was reused');\n"
-        "  const started = await options.docker.run(['run', '-d', 'blazegraph']);\n"
-        "  return {url: started.stdout.trim(), port: options.port, managedByDkg: true};\n"
+        "  if (inspected.exitCode !== 0) throw new Error('legacy container was replaced');\n"
+        "  return {url: 'reused', port: options.port, managedByDkg: true};\n"
         "}\n",
         encoding="utf-8",
     )
@@ -1361,8 +1360,8 @@ def test_blazegraph_helper_sizes_heap_and_preserves_undersized_store(tmp_path: P
         "#!/bin/sh\n"
         f"printf '%s\\n' \"$*\" >> {shlex.quote(str(docker_log))}\n"
         "case \"$1\" in\n"
-        "  inspect) printf '%s\\n' '[{\"Config\":{\"Env\":[\"JAVA_OPTS=-Xmx1g\"]}}]' ;;\n"
-        "  run) printf '%s\\n' \"$*\" ;;\n"
+        "  inspect) printf '%s\\n' '[{\"Config\":{\"Image\":\"islandora/blazegraph:6.4.3\",\"Env\":[\"JAVA_OPTS=-Xms512m -Xmx4g\",\"TOMCAT_JAVA_OPTS=\"]},\"State\":{\"Running\":true}}]' ;;\n"
+        "  exec) case \"$*\" in *grep*) exit 1 ;; esac ;;\n"
         "esac\n",
         encoding="utf-8",
     )
@@ -1378,10 +1377,98 @@ def test_blazegraph_helper_sizes_heap_and_preserves_undersized_store(tmp_path: P
 
     calls = docker_log.read_text(encoding="utf-8").splitlines()
     assert calls[0] == "inspect dkg-blazegraph-test"
-    assert calls[1] == "stop dkg-blazegraph-test"
-    assert calls[2].startswith("rename dkg-blazegraph-test dkg-blazegraph-test-pre-4g-")
-    assert calls[3] == "run --cpus 4 -e JAVA_OPTS=-Xms512m -Xmx4g -d blazegraph"
-    assert json.loads(completed.stdout)["url"] == calls[3]
+    assert calls[1].startswith(
+        "exec --user 0 dkg-blazegraph-test sh -c grep -Fq "
+    )
+    assert "blackbox-effective-blazegraph-heap" in calls[1]
+    assert calls[2].startswith("exec --user 0 dkg-blazegraph-test sh -c set -eu;")
+    assert 'export JAVA_OPTS="-Xms512m -Xmx4g"' in calls[2]
+    assert calls[3] == "restart dkg-blazegraph-test"
+    assert calls[4] == "update --cpus 4 dkg-blazegraph-test"
+    assert all(not call.startswith(("stop ", "rename ", "rm ")) for call in calls)
+    assert json.loads(completed.stdout)["url"] == "reused"
+
+
+def test_blazegraph_helper_sets_effective_tomcat_heap_on_new_container(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is not installed")
+    cli = tmp_path / "node_modules" / "@origintrail-official" / "dkg"
+    module = cli / "dist" / "daemon" / "blazegraph-docker.js"
+    module.parent.mkdir(parents=True)
+    (cli / "package.json").write_text('{"type":"module"}', encoding="utf-8")
+    module.write_text(
+        "export async function provisionBlazegraphDocker(options) {\n"
+        "  const started = await options.docker.run(['run', '-d', 'blazegraph']);\n"
+        "  return {url: started.stdout.trim(), port: options.port, managedByDkg: true};\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    docker_log = tmp_path / "docker.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker = fake_bin / "docker"
+    docker.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$*\" >> {shlex.quote(str(docker_log))}\n"
+        "printf '%s\\n' \"$*\"\n",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+
+    completed = subprocess.run(
+        [node, str(BLAZEGRAPH_HELPER), str(tmp_path), "blackbox-test", "10001"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(fake_bin) + os.pathsep + os.environ.get("PATH", "")},
+    )
+
+    calls = docker_log.read_text(encoding="utf-8").splitlines()
+    assert calls == [
+        "run --cpus 4 -e TOMCAT_JAVA_OPTS=-Xms512m -Xmx4g -d blazegraph"
+    ]
+    assert json.loads(completed.stdout)["url"] == calls[0]
+
+
+def test_blazegraph_helper_refuses_to_replace_unknown_legacy_store(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is not installed")
+    cli = tmp_path / "node_modules" / "@origintrail-official" / "dkg"
+    module = cli / "dist" / "daemon" / "blazegraph-docker.js"
+    module.parent.mkdir(parents=True)
+    (cli / "package.json").write_text('{"type":"module"}', encoding="utf-8")
+    module.write_text(
+        "export async function provisionBlazegraphDocker(options) {\n"
+        "  await options.docker.run(['inspect', 'dkg-blazegraph-test']);\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    docker_log = tmp_path / "docker.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker = fake_bin / "docker"
+    docker.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$*\" >> {shlex.quote(str(docker_log))}\n"
+        "printf '%s\\n' '[{\"Config\":{\"Image\":\"unknown/blazegraph:latest\",\"Env\":[]},\"State\":{\"Running\":true}}]'\n",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+
+    completed = subprocess.run(
+        [node, str(BLAZEGRAPH_HELPER), str(tmp_path), "blackbox-test", "10001"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(fake_bin) + os.pathsep + os.environ.get("PATH", "")},
+    )
+
+    assert completed.returncode != 0
+    assert "Refusing to replace it" in completed.stderr
+    assert docker_log.read_text(encoding="utf-8").splitlines() == [
+        "inspect dkg-blazegraph-test"
+    ]
 
 
 def test_blazegraph_helper_uses_dkg_store_health_check(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Ensure Blackbox-owned Blazegraph instances actually start with the intended 4 GiB Java heap, and safely repair existing pinned containers without replacing their local graph store.

The Blackbox installer previously injected and validated `JAVA_OPTS=-Xms512m -Xmx4g`. The pinned `islandora/blazegraph` image runs `/opt/tomcat/bin/setenv.sh`, which replaces `JAVA_OPTS` with `TOMCAT_JAVA_OPTS`. Because `TOMCAT_JAVA_OPTS` was empty, the live JVM ignored the intended setting and auto-sized to roughly 1.9 GiB.

Under a large verified-VM deduplication query and concurrent insert, that smaller heap can exhaust. An uncaught `OutOfMemoryError` can terminate Tomcat's NIO poller while leaving the main JVM and Docker container alive. The resulting container accepts TCP connections but never dispatches HTTP requests, so DKG store operations queue and sync eventually times out.

## Root cause

```mermaid
sequenceDiagram
    participant Installer as Blackbox installer
    participant Container as Blazegraph container
    participant Setenv as Tomcat setenv.sh
    participant JVM as Blazegraph JVM
    participant DKG as DKG sync

    Installer->>Container: docker run -e JAVA_OPTS=-Xms512m -Xmx4g
    Container->>Setenv: Start Tomcat
    Setenv->>JVM: JAVA_OPTS = TOMCAT_JAVA_OPTS (empty)
    Note over JVM: Effective max heap auto-sizes below 2 GiB
    DKG->>JVM: Large dedup query and graph insert
    JVM--xJVM: OutOfMemoryError kills NIO poller
    DKG->>JVM: Status, query, and insert requests
    Note over JVM: TCP accepts, but HTTP dispatch makes no progress
    JVM--xDKG: Store queue waits and sync deadline expires
```

This is a process-liveness versus service-liveness failure: Docker still reports the container as running, but the HTTP service is no longer usable.

## Changes

### Correct fresh installations

- Inject `TOMCAT_JAVA_OPTS=-Xms512m -Xmx4g`, which is the variable the pinned image consumes.
- Validate the configured heap using `TOMCAT_JAVA_OPTS`, not the shadowed `JAVA_OPTS` value.
- Preserve the existing four-CPU Blackbox limit.

```mermaid
sequenceDiagram
    participant Installer as Blackbox installer
    participant Docker
    participant Setenv as Tomcat setenv.sh
    participant JVM as Blazegraph JVM

    Installer->>Docker: docker run -e TOMCAT_JAVA_OPTS=-Xms512m -Xmx4g
    Docker->>Setenv: Start pinned image
    Setenv->>JVM: JAVA_OPTS = TOMCAT_JAVA_OPTS
    JVM-->>Installer: Blazegraph ready with effective 4 GiB max heap
```

### Repair existing pinned containers in place

- Detect missing or undersized effective Tomcat heap configuration.
- Restrict automatic repair to the pinned `islandora/blazegraph` image family.
- Back up the image's current `setenv.sh` inside the same container.
- Add an idempotent, marker-protected 4 GiB effective heap override.
- Restart the same container so its existing `/data` journal remains in place.
- Let the DKG provisioner start stopped containers first, then repair them on the post-start inspection.
- Refuse to replace unknown images because their graph data may not be mounted durably.

```mermaid
sequenceDiagram
    participant Installer as Blackbox installer
    participant Docker
    participant Existing as Existing Blazegraph container
    participant Data as Existing /data journal

    Installer->>Docker: Inspect existing container
    Docker-->>Installer: Missing or undersized TOMCAT_JAVA_OPTS
    alt Pinned islandora/blazegraph image
        Installer->>Existing: Check idempotent repair marker
        alt Marker absent
            Installer->>Existing: Back up and patch setenv.sh
            Installer->>Docker: Restart same container
            Existing->>Data: Reopen existing journal
        else Marker present
            Note over Installer,Existing: Reuse without another restart
        end
        Installer->>Docker: Reapply four-CPU limit
    else Unknown image
        Installer--xDocker: Fail closed without stop, rename, remove, or replacement
    end
```

## Data-safety boundary

The previous migration path stopped and renamed an undersized container before provisioning a replacement. That preserved the old container as a backup, but the new instance could start with an empty graph store when the legacy journal was not mounted in the expected named volume.

This change removes that replacement behavior for heap repair. Existing pinned containers are modified and restarted in place, while unsupported images are left untouched with an actionable error.

## Tests

```text
python3 -m pytest -q tests/test_blackbox_install_llm_setup.py
61 passed in 6.04s
```

Regression coverage verifies:

- fresh containers receive `TOMCAT_JAVA_OPTS=-Xms512m -Xmx4g`;
- a legacy container is patched and restarted in place;
- no `stop`, `rename`, `rm`, or replacement operation occurs during legacy repair;
- the repair is marker-protected;
- unsupported legacy images fail closed;
- the existing Unix and Windows installer contracts remain green.

## Operational impact

- New installations start with the intended effective heap immediately.
- Existing pinned installations receive one controlled Blazegraph restart the next time provisioning runs.
- Graph data, DKG configuration, sync semantics, and the DKG runtime are not rewritten by this patch.
- This prevents the confirmed heap-variable mismatch; memory-heavy query behavior should still remain bounded independently.
